### PR TITLE
Add configurable geometric crown profile models (cone, cylinder, paraboloid, ellipsoid)

### DIFF
--- a/fastfuels_core/crown_profile_models/beta.py
+++ b/fastfuels_core/crown_profile_models/beta.py
@@ -58,6 +58,24 @@ class BetaCrownProfile(CrownProfileModel):
         result = normalized_max_radius * self.crown_length
         return result.item() if result.size == 1 else result
 
+    def get_max_radius_height(self) -> float | np.ndarray:
+        """
+        Returns the absolute height (m) at which the crown attains its maximum
+        radius: the mode of the beta distribution expressed in tree
+        coordinates, crown_base_height + z_max * crown_length, where
+        z_max = (a - 1) / (a + b - 2).
+
+        This is the quantity LANL Trees uses to place the peak of its
+        double-paraboloid crown (its "height to max crown diameter"). Pass the
+        result as max_crown_diameter_height to a ParaboloidCrownProfile or
+        EllipsoidCrownProfile to reproduce that geometry.
+
+        Returns a scalar with scalar input, a vector with vector input.
+        """
+        z_max = (self.a - 1) / (self.a + self.b - 2)
+        result = self.crown_base_height + z_max * self.crown_length
+        return result.item() if result.size == 1 else result.reshape(-1)
+
     def get_radius_at_height(self, height) -> float | np.ndarray:
         """
         Returns the radius of the crown at a given height using the beta

--- a/fastfuels_core/crown_profile_models/cone.py
+++ b/fastfuels_core/crown_profile_models/cone.py
@@ -1,0 +1,91 @@
+# Core imports
+from __future__ import annotations
+
+# Internal imports
+from fastfuels_core.crown_profile_models.abc import CrownProfileModel
+
+# External imports
+import numpy as np
+from numpy.typing import NDArray
+
+
+class ConeCrownProfile(CrownProfileModel):
+    """
+    Cone crown profile.
+
+    A single right circular cone that is widest at the crown base and tapers
+    linearly to a point at the tree top:
+
+        R(z) = R * (Ht - z) / (Ht - Hb)     for Hb <= z <= Ht
+
+    where Hb is the crown base height, Ht the total tree height, and R the
+    maximum crown radius (attained at the crown base). This is a single cone,
+    not a bicone. A max crown diameter height does not apply.
+
+    Parameters
+    ----------
+    crown_base_height : float or NDArray[np.float64]
+        Height at which the live crown starts (m).
+    height : float or NDArray[np.float64]
+        Total height of the tree (m).
+    max_crown_radius : float or NDArray[np.float64]
+        Maximum crown radius (m), attained at the crown base.
+
+    Notes
+    -----
+    All parameters are stored as 2D arrays with shape [n_trees, 1] to enable
+    natural broadcasting with 1D height inputs, matching PurvesCrownProfile and
+    BetaCrownProfile.
+    """
+
+    crown_base_height: NDArray[np.float64]
+    height: NDArray[np.float64]
+    max_crown_radius: NDArray[np.float64]
+
+    def __init__(
+        self,
+        crown_base_height: float | NDArray[np.float64],
+        height: float | NDArray[np.float64],
+        max_crown_radius: float | NDArray[np.float64],
+    ):
+        self.crown_base_height = np.atleast_2d(crown_base_height).T
+        self.height = np.atleast_2d(height).T
+        self.max_crown_radius = np.atleast_2d(max_crown_radius).T
+
+    def get_radius_at_height(self, height) -> float | np.ndarray:
+        """
+        Returns the crown radius at the given height(s).
+
+        Returns a scalar for a single tree/height, a 1D array for a single tree
+        with multiple heights, and a 2D array [n_trees, n_heights] for multiple
+        trees.
+        """
+        z = np.asarray(height)
+        crown_length = self.height - self.crown_base_height
+        # Guard against a zero-length crown (crown_ratio == 0); the crown mask
+        # below zeroes out every cell in that case anyway.
+        safe_length = np.where(crown_length == 0, 1.0, crown_length)
+
+        radius = self.max_crown_radius * (self.height - z) / safe_length
+        inside = (z >= self.crown_base_height) & (z <= self.height)
+        result = np.where(inside, radius, 0.0)
+
+        if result.size == 1:
+            return result.item()
+        elif result.shape[0] == 1:
+            return result.squeeze()
+        else:
+            return result
+
+    def get_max_radius(self) -> float | np.ndarray:
+        """Returns the maximum crown radius (attained at the crown base)."""
+        r = self.max_crown_radius
+        return r.item() if r.size == 1 else r.reshape(-1)
+
+    def get_max_radius_height(self) -> float | np.ndarray:
+        """
+        Returns the height (m) of maximum crown radius. The cone tapers upward
+        from the crown base, so the maximum is attained at the crown base.
+        """
+        result = self.crown_base_height
+        return result.item() if result.size == 1 else result.reshape(-1)

--- a/fastfuels_core/crown_profile_models/cylinder.py
+++ b/fastfuels_core/crown_profile_models/cylinder.py
@@ -1,0 +1,86 @@
+# Core imports
+from __future__ import annotations
+
+# Internal imports
+from fastfuels_core.crown_profile_models.abc import CrownProfileModel
+
+# External imports
+import numpy as np
+from numpy.typing import NDArray
+
+
+class CylinderCrownProfile(CrownProfileModel):
+    """
+    Cylinder crown profile.
+
+    A right circular cylinder of uniform radius between the crown base and the
+    tree top:
+
+        R(z) = R     for Hb <= z <= Ht
+
+    where Hb is the crown base height, Ht the total tree height, and R the
+    (constant) crown radius. A max crown diameter height does not apply.
+
+    Parameters
+    ----------
+    crown_base_height : float or NDArray[np.float64]
+        Height at which the live crown starts (m).
+    height : float or NDArray[np.float64]
+        Total height of the tree (m).
+    max_crown_radius : float or NDArray[np.float64]
+        Crown radius (m), uniform over the crown.
+
+    Notes
+    -----
+    All parameters are stored as 2D arrays with shape [n_trees, 1] to enable
+    natural broadcasting with 1D height inputs, matching PurvesCrownProfile and
+    BetaCrownProfile.
+    """
+
+    crown_base_height: NDArray[np.float64]
+    height: NDArray[np.float64]
+    max_crown_radius: NDArray[np.float64]
+
+    def __init__(
+        self,
+        crown_base_height: float | NDArray[np.float64],
+        height: float | NDArray[np.float64],
+        max_crown_radius: float | NDArray[np.float64],
+    ):
+        self.crown_base_height = np.atleast_2d(crown_base_height).T
+        self.height = np.atleast_2d(height).T
+        self.max_crown_radius = np.atleast_2d(max_crown_radius).T
+
+    def get_radius_at_height(self, height) -> float | np.ndarray:
+        """
+        Returns the crown radius at the given height(s).
+
+        Returns a scalar for a single tree/height, a 1D array for a single tree
+        with multiple heights, and a 2D array [n_trees, n_heights] for multiple
+        trees.
+        """
+        z = np.asarray(height)
+        inside = (z >= self.crown_base_height) & (z <= self.height)
+        result = np.where(inside, self.max_crown_radius, 0.0)
+
+        if result.size == 1:
+            return result.item()
+        elif result.shape[0] == 1:
+            return result.squeeze()
+        else:
+            return result
+
+    def get_max_radius(self) -> float | np.ndarray:
+        """Returns the (uniform) crown radius."""
+        r = self.max_crown_radius
+        return r.item() if r.size == 1 else r.reshape(-1)
+
+    def get_max_radius_height(self) -> float | np.ndarray:
+        """
+        Returns a representative height (m) of maximum crown radius. The radius
+        is uniform over [crown_base_height, height], so the maximum is attained
+        at every height in the crown and there is no unique maximum; the crown
+        midpoint is returned as a representative value.
+        """
+        result = (self.crown_base_height + self.height) / 2.0
+        return result.item() if result.size == 1 else result.reshape(-1)

--- a/fastfuels_core/crown_profile_models/ellipsoid.py
+++ b/fastfuels_core/crown_profile_models/ellipsoid.py
@@ -1,0 +1,129 @@
+# Core imports
+from __future__ import annotations
+
+# Internal imports
+from fastfuels_core.crown_profile_models.abc import CrownProfileModel
+
+# External imports
+import numpy as np
+from numpy.typing import NDArray
+
+
+class EllipsoidCrownProfile(CrownProfileModel):
+    """
+    Double half-ellipsoid crown profile.
+
+    Two half-ellipsoids of revolution joined at the height of maximum crown
+    diameter, Hd, peaking there at the maximum crown radius R and tapering to
+    zero at the crown base Hb and the tree top Ht:
+
+        lower (Hb <= z <= Hd): R(z) = R * sqrt(1 - ((Hd - z) / (Hd - Hb))**2)
+        upper (Hd <= z <= Ht): R(z) = R * sqrt(1 - ((z - Hd) / (Ht - Hd))**2)
+
+    When Hd is the crown midpoint the two lobes have equal vertical semi-axes
+    and the solid is a symmetric spheroid. A single half-ellipsoid is the
+    limiting case of the dual form: pass ``max_crown_diameter_height == Hb`` for
+    a crown widest at the base, or ``== Ht`` for one widest at the top; any
+    interior value gives the two-lobed peak.
+
+    Parameters
+    ----------
+    crown_base_height : float or NDArray[np.float64]
+        Height at which the live crown starts (m).
+    height : float or NDArray[np.float64]
+        Total height of the tree (m).
+    max_crown_radius : float or NDArray[np.float64]
+        Maximum crown radius (m), attained at max_crown_diameter_height.
+    max_crown_diameter_height : float or NDArray[np.float64], optional
+        Height of maximum crown diameter (m). Must lie within
+        [crown_base_height, height]. Defaults to the crown midpoint
+        (crown_base_height + height) / 2 when not provided.
+
+    Notes
+    -----
+    All parameters are stored as 2D arrays with shape [n_trees, 1] to enable
+    natural broadcasting with 1D height inputs, matching PurvesCrownProfile and
+    BetaCrownProfile.
+    """
+
+    crown_base_height: NDArray[np.float64]
+    height: NDArray[np.float64]
+    max_crown_radius: NDArray[np.float64]
+    max_crown_diameter_height: NDArray[np.float64]
+
+    def __init__(
+        self,
+        crown_base_height: float | NDArray[np.float64],
+        height: float | NDArray[np.float64],
+        max_crown_radius: float | NDArray[np.float64],
+        max_crown_diameter_height: float | NDArray[np.float64] | None = None,
+    ):
+        self.crown_base_height = np.atleast_2d(crown_base_height).T
+        self.height = np.atleast_2d(height).T
+        self.max_crown_radius = np.atleast_2d(max_crown_radius).T
+        if max_crown_diameter_height is None:
+            self.max_crown_diameter_height = (
+                self.crown_base_height + self.height
+            ) / 2.0
+        else:
+            self.max_crown_diameter_height = np.atleast_2d(max_crown_diameter_height).T
+        self._validate_diameter_height()
+
+    def _validate_diameter_height(self):
+        hd = self.max_crown_diameter_height
+        if np.any(hd < self.crown_base_height) or np.any(hd > self.height):
+            raise ValueError(
+                "max_crown_diameter_height must lie within "
+                "[crown_base_height, height] for every tree."
+            )
+
+    def get_radius_at_height(self, height) -> float | np.ndarray:
+        """
+        Returns the crown radius at the given height(s).
+
+        Returns a scalar for a single tree/height, a 1D array for a single tree
+        with multiple heights, and a 2D array [n_trees, n_heights] for multiple
+        trees.
+        """
+        z = np.asarray(height)
+        hb = self.crown_base_height
+        ht = self.height
+        hd = self.max_crown_diameter_height
+        r = self.max_crown_radius
+
+        lower_len = hd - hb
+        upper_len = ht - hd
+        # Guard degenerate (zero-length) lobes for the single-ellipsoid limiting
+        # cases Hd == Hb or Hd == Ht. The denominators are made safe here and the
+        # lobe-selection / crown mask below ensure the empty lobe is never used.
+        safe_lower = np.where(lower_len == 0, 1.0, lower_len)
+        safe_upper = np.where(upper_len == 0, 1.0, upper_len)
+
+        # Clip the sqrt argument to [0, 1]: np.where evaluates both branches, so
+        # out-of-lobe cells would otherwise take a sqrt of a negative number.
+        lower = r * np.sqrt(np.clip(1.0 - ((hd - z) / safe_lower) ** 2, 0.0, 1.0))
+        upper = r * np.sqrt(np.clip(1.0 - ((z - hd) / safe_upper) ** 2, 0.0, 1.0))
+
+        # Use the lower lobe only where it is non-degenerate; when Hd == Hb the
+        # upper lobe covers the whole crown (both give R at the shared peak).
+        use_lower = (z <= hd) & (lower_len > 0)
+        radius = np.where(use_lower, lower, upper)
+        inside = (z >= hb) & (z <= ht)
+        result = np.where(inside, radius, 0.0)
+
+        if result.size == 1:
+            return result.item()
+        elif result.shape[0] == 1:
+            return result.squeeze()
+        else:
+            return result
+
+    def get_max_radius(self) -> float | np.ndarray:
+        """Returns the maximum crown radius (attained at Hd)."""
+        r = self.max_crown_radius
+        return r.item() if r.size == 1 else r.reshape(-1)
+
+    def get_max_radius_height(self) -> float | np.ndarray:
+        """Returns the height (m) of maximum crown radius (Hd)."""
+        result = self.max_crown_diameter_height
+        return result.item() if result.size == 1 else result.reshape(-1)

--- a/fastfuels_core/crown_profile_models/paraboloid.py
+++ b/fastfuels_core/crown_profile_models/paraboloid.py
@@ -1,0 +1,128 @@
+# Core imports
+from __future__ import annotations
+
+# Internal imports
+from fastfuels_core.crown_profile_models.abc import CrownProfileModel
+
+# External imports
+import numpy as np
+from numpy.typing import NDArray
+
+
+class ParaboloidCrownProfile(CrownProfileModel):
+    """
+    Double-paraboloid crown profile.
+
+    Two paraboloids of revolution joined at the height of maximum crown
+    diameter, Hd, peaking there at the maximum crown radius R and tapering to
+    zero at the crown base Hb and the tree top Ht:
+
+        lower (Hb <= z <= Hd): R(z) = R * sqrt((z - Hb) / (Hd - Hb))
+        upper (Hd <= z <= Ht): R(z) = R * sqrt((Ht - z) / (Ht - Hd))
+
+    This is the crown envelope used by LANL Trees. A single paraboloid is the
+    limiting case of the dual form: pass ``max_crown_diameter_height == Hb`` for
+    a crown widest at the base, or ``== Ht`` for one widest at the top; any
+    interior value gives the two-lobed peak.
+
+    Parameters
+    ----------
+    crown_base_height : float or NDArray[np.float64]
+        Height at which the live crown starts (m).
+    height : float or NDArray[np.float64]
+        Total height of the tree (m).
+    max_crown_radius : float or NDArray[np.float64]
+        Maximum crown radius (m), attained at max_crown_diameter_height.
+    max_crown_diameter_height : float or NDArray[np.float64], optional
+        Height of maximum crown diameter (m). Must lie within
+        [crown_base_height, height]. Defaults to the crown midpoint
+        (crown_base_height + height) / 2 when not provided.
+
+    Notes
+    -----
+    All parameters are stored as 2D arrays with shape [n_trees, 1] to enable
+    natural broadcasting with 1D height inputs, matching PurvesCrownProfile and
+    BetaCrownProfile.
+    """
+
+    crown_base_height: NDArray[np.float64]
+    height: NDArray[np.float64]
+    max_crown_radius: NDArray[np.float64]
+    max_crown_diameter_height: NDArray[np.float64]
+
+    def __init__(
+        self,
+        crown_base_height: float | NDArray[np.float64],
+        height: float | NDArray[np.float64],
+        max_crown_radius: float | NDArray[np.float64],
+        max_crown_diameter_height: float | NDArray[np.float64] | None = None,
+    ):
+        self.crown_base_height = np.atleast_2d(crown_base_height).T
+        self.height = np.atleast_2d(height).T
+        self.max_crown_radius = np.atleast_2d(max_crown_radius).T
+        if max_crown_diameter_height is None:
+            self.max_crown_diameter_height = (
+                self.crown_base_height + self.height
+            ) / 2.0
+        else:
+            self.max_crown_diameter_height = np.atleast_2d(max_crown_diameter_height).T
+        self._validate_diameter_height()
+
+    def _validate_diameter_height(self):
+        hd = self.max_crown_diameter_height
+        if np.any(hd < self.crown_base_height) or np.any(hd > self.height):
+            raise ValueError(
+                "max_crown_diameter_height must lie within "
+                "[crown_base_height, height] for every tree."
+            )
+
+    def get_radius_at_height(self, height) -> float | np.ndarray:
+        """
+        Returns the crown radius at the given height(s).
+
+        Returns a scalar for a single tree/height, a 1D array for a single tree
+        with multiple heights, and a 2D array [n_trees, n_heights] for multiple
+        trees.
+        """
+        z = np.asarray(height)
+        hb = self.crown_base_height
+        ht = self.height
+        hd = self.max_crown_diameter_height
+        r = self.max_crown_radius
+
+        lower_len = hd - hb
+        upper_len = ht - hd
+        # Guard degenerate (zero-length) lobes for the single-paraboloid limiting
+        # cases Hd == Hb or Hd == Ht. The denominators are made safe here and the
+        # lobe-selection / crown mask below ensure the empty lobe is never used.
+        safe_lower = np.where(lower_len == 0, 1.0, lower_len)
+        safe_upper = np.where(upper_len == 0, 1.0, upper_len)
+
+        # Clip the sqrt argument to [0, 1]: np.where evaluates both branches, so
+        # out-of-lobe cells would otherwise take a sqrt of a negative number.
+        lower = r * np.sqrt(np.clip((z - hb) / safe_lower, 0.0, 1.0))
+        upper = r * np.sqrt(np.clip((ht - z) / safe_upper, 0.0, 1.0))
+
+        # Use the lower lobe only where it is non-degenerate; when Hd == Hb the
+        # upper lobe covers the whole crown (both give R at the shared peak).
+        use_lower = (z <= hd) & (lower_len > 0)
+        radius = np.where(use_lower, lower, upper)
+        inside = (z >= hb) & (z <= ht)
+        result = np.where(inside, radius, 0.0)
+
+        if result.size == 1:
+            return result.item()
+        elif result.shape[0] == 1:
+            return result.squeeze()
+        else:
+            return result
+
+    def get_max_radius(self) -> float | np.ndarray:
+        """Returns the maximum crown radius (attained at Hd)."""
+        r = self.max_crown_radius
+        return r.item() if r.size == 1 else r.reshape(-1)
+
+    def get_max_radius_height(self) -> float | np.ndarray:
+        """Returns the height (m) of maximum crown radius (Hd)."""
+        result = self.max_crown_diameter_height
+        return result.item() if result.size == 1 else result.reshape(-1)

--- a/fastfuels_core/crown_profile_models/purves.py
+++ b/fastfuels_core/crown_profile_models/purves.py
@@ -9,7 +9,6 @@ from fastfuels_core.crown_profile_models.abc import CrownProfileModel
 import numpy as np
 from numpy.typing import NDArray
 
-
 # See Purves et al. (2007) Table S2 in Supporting Information
 C0_R0 = 0.503
 C1_R0 = 3.126
@@ -178,6 +177,17 @@ class PurvesCrownProfile(CrownProfileModel):
         """
         max_radius = self.get_radius_at_height(self.crown_base_height)
         return max_radius if isinstance(max_radius, float) else max_radius.reshape(-1)
+
+    def get_max_radius_height(self) -> float | np.ndarray:
+        """
+        Returns the height (m) of maximum crown radius. The Purves profile
+        decreases monotonically from the crown base upward, so the maximum
+        radius is attained at the crown base height.
+
+        Returns a scalar with scalar input, a vector with vector input.
+        """
+        result = self.crown_base_height
+        return result.item() if result.size == 1 else result.reshape(-1)
 
     def _get_purves_shape_param(self):
         """

--- a/fastfuels_core/trees.py
+++ b/fastfuels_core/trees.py
@@ -10,6 +10,10 @@ from fastfuels_core.treatments import TreatmentProtocol
 from fastfuels_core.crown_profile_models.abc import CrownProfileModel
 from fastfuels_core.crown_profile_models.purves import PurvesCrownProfile
 from fastfuels_core.crown_profile_models.beta import BetaCrownProfile
+from fastfuels_core.crown_profile_models.cone import ConeCrownProfile
+from fastfuels_core.crown_profile_models.cylinder import CylinderCrownProfile
+from fastfuels_core.crown_profile_models.paraboloid import ParaboloidCrownProfile
+from fastfuels_core.crown_profile_models.ellipsoid import EllipsoidCrownProfile
 from fastfuels_core.ref_data import REF_SPECIES, REF_JENKINS, REF_TRY_DB_LEAF
 
 # External Imports
@@ -18,6 +22,11 @@ import pandas as pd
 from numpy import ndarray
 from nsvb.estimators import total_foliage_dry_weight
 from pandera.pandas import DataFrameSchema, Column, Check, Index
+
+# Geometric crown profiles. These require a mandatory max_crown_radius; the
+# paraboloid and ellipsoid additionally accept max_crown_diameter_height.
+_GEOMETRIC_PROFILE_TYPES = ("cone", "cylinder", "paraboloid", "ellipsoid")
+_VALID_PROFILE_TYPES = ("purves", "beta") + _GEOMETRIC_PROFILE_TYPES
 
 TREE_SCHEMA_COLS = {
     "TREE_ID": Column(int),
@@ -208,10 +217,16 @@ class Tree:
     y : float
         Y coordinate of the tree in a projected coordinate system. Units: m.
     max_crown_radius : float, optional
-        Measured maximum crown radius (m). When provided, the allometric crown
-        profile shape is preserved but scaled so that the maximum radius matches
-        this value. If None (default), the crown radius is computed entirely
-        from allometric equations based on species and diameter.
+        Measured maximum crown radius (m). For the allometric profiles ('purves',
+        'beta'), when provided the crown profile shape is preserved but scaled so
+        that the maximum radius matches this value; if None (default) the crown
+        radius is computed entirely from allometric equations. For the geometric
+        profiles ('cone', 'cylinder', 'paraboloid', 'ellipsoid') it is the
+        defining crown radius and is required.
+    max_crown_diameter_height : float, optional
+        Height (m) of maximum crown diameter. Used only by the 'paraboloid' and
+        'ellipsoid' profiles to place their peak; ignored by the other profiles.
+        Defaults to the crown midpoint when not provided.
     crown_fuel_load : float, optional
         Pre-computed crown foliage biomass (kg). When provided, this value is
         returned directly by the foliage_biomass property instead of computing
@@ -239,6 +254,7 @@ class Tree:
         crown_profile_model_type="purves",
         biomass_allometry_model_type="NSVB",
         max_crown_radius=None,
+        max_crown_diameter_height=None,
         crown_fuel_load=None,
     ):
         # TODO: Species code needs to be valid
@@ -260,9 +276,18 @@ class Tree:
         # Optional parameters
         self._jenkins_species_group = jenkins_species_group
 
-        if crown_profile_model_type not in ["beta", "purves"]:
+        if crown_profile_model_type not in _VALID_PROFILE_TYPES:
             raise ValueError(
-                "The crown profile model must be one of the following: 'beta' or 'purves'"
+                "The crown profile model must be one of the following: "
+                f"{', '.join(_VALID_PROFILE_TYPES)}"
+            )
+        if (
+            crown_profile_model_type in _GEOMETRIC_PROFILE_TYPES
+            and max_crown_radius is None
+        ):
+            raise ValueError(
+                "max_crown_radius is required for geometric crown profiles "
+                f"({', '.join(_GEOMETRIC_PROFILE_TYPES)})."
             )
         self._crown_profile_model_type = crown_profile_model_type
 
@@ -276,6 +301,7 @@ class Tree:
         self._biomass_allometry_model_type = biomass_allometry_model_type
 
         self._max_crown_radius_override = max_crown_radius
+        self._max_crown_diameter_height = max_crown_diameter_height
         self._crown_fuel_load_override = crown_fuel_load
 
     @property
@@ -318,6 +344,28 @@ class Tree:
         elif self._crown_profile_model_type == "purves":
             return PurvesCrownProfile(
                 self.species_code, self.diameter, self.height, self.crown_ratio
+            )
+        elif self._crown_profile_model_type == "cone":
+            return ConeCrownProfile(
+                self.crown_base_height, self.height, self._max_crown_radius_override
+            )
+        elif self._crown_profile_model_type == "cylinder":
+            return CylinderCrownProfile(
+                self.crown_base_height, self.height, self._max_crown_radius_override
+            )
+        elif self._crown_profile_model_type == "paraboloid":
+            return ParaboloidCrownProfile(
+                self.crown_base_height,
+                self.height,
+                self._max_crown_radius_override,
+                self._max_crown_diameter_height,
+            )
+        elif self._crown_profile_model_type == "ellipsoid":
+            return EllipsoidCrownProfile(
+                self.crown_base_height,
+                self.height,
+                self._max_crown_radius_override,
+                self._max_crown_diameter_height,
             )
 
     @property

--- a/tests/crown_profile_models/test_beta.py
+++ b/tests/crown_profile_models/test_beta.py
@@ -153,6 +153,33 @@ class TestGetMaxRadius:
         assert np.all(max_crown_radius > 0.0)
 
 
+class TestGetMaxRadiusHeight:
+    def test_returns_scalar_in_crown(self, model):
+        # model: crown_base_height=10, crown_length=10 -> crown spans [10, 20]
+        hd = model.get_max_radius_height()
+        assert isinstance(hd, float)
+        assert 10.0 <= hd <= 20.0
+
+    def test_coincides_with_argmax(self, model):
+        z = np.linspace(10.0, 20.0, 10001)
+        r = model.get_radius_at_height(z)
+        assert z[np.argmax(r)] == pytest.approx(model.get_max_radius_height(), abs=0.01)
+
+    @pytest.mark.parametrize("spcd", LIST_SPCDS)
+    def test_vector_input(self, spcd):
+        cbh = np.array([5.0, 10.0, 2.0])
+        cl = np.array([10.0, 8.0, 15.0])
+        beta_model = BetaCrownProfile(
+            species_code=np.array([spcd, spcd, spcd]),
+            crown_base_height=cbh,
+            crown_length=cl,
+        )
+        hd = beta_model.get_max_radius_height()
+        assert isinstance(hd, np.ndarray)
+        assert hd.shape == (3,)
+        assert np.all(hd >= cbh) and np.all(hd <= cbh + cl)
+
+
 class TestGetRadiusAtHeight:
     @pytest.mark.parametrize("spcd", LIST_SPCDS)
     def test_scalar_height_input(self, spcd):

--- a/tests/crown_profile_models/test_cone.py
+++ b/tests/crown_profile_models/test_cone.py
@@ -1,0 +1,77 @@
+"""
+tests/crown_profile_models/test_cone.py
+"""
+
+# Internal imports
+from fastfuels_core.crown_profile_models.cone import ConeCrownProfile
+
+# External imports
+import numpy as np
+import pytest
+
+HB, HT, R = 10.0, 20.0, 3.0
+
+
+@pytest.fixture
+def model():
+    return ConeCrownProfile(crown_base_height=HB, height=HT, max_crown_radius=R)
+
+
+class TestGetMaxRadius:
+    def test_returns_r(self, model):
+        assert model.get_max_radius() == pytest.approx(R)
+
+    def test_max_radius_height_is_base(self, model):
+        assert model.get_max_radius_height() == pytest.approx(HB)
+
+
+class TestGetRadiusAtHeight:
+    def test_widest_at_base(self, model):
+        assert model.get_radius_at_height(HB) == pytest.approx(R)
+
+    def test_zero_at_top(self, model):
+        assert model.get_radius_at_height(HT) == pytest.approx(0.0)
+
+    def test_half_at_midpoint(self, model):
+        assert model.get_radius_at_height((HB + HT) / 2) == pytest.approx(R / 2)
+
+    def test_linear_profile(self, model):
+        z = np.linspace(HB, HT, 50)
+        expected = R * (HT - z) / (HT - HB)
+        assert np.allclose(model.get_radius_at_height(z), expected)
+
+    def test_outside_crown_is_zero(self, model):
+        assert model.get_radius_at_height(HB - 1.0) == 0.0
+        assert model.get_radius_at_height(HT + 1.0) == 0.0
+        assert model.get_radius_at_height(-5.0) == 0.0
+        assert model.get_radius_at_height(1e6) == 0.0
+
+    def test_scalar_returns_float(self, model):
+        assert isinstance(model.get_radius_at_height(15.0), float)
+
+    def test_1d_returns_1d(self, model):
+        z = np.linspace(HB, HT, 20)
+        r = model.get_radius_at_height(z)
+        assert isinstance(r, np.ndarray)
+        assert r.shape == z.shape
+        assert np.all(r >= 0.0)
+        assert np.all(r <= R + 1e-9)
+
+    def test_multiple_trees_returns_2d(self):
+        model = ConeCrownProfile(
+            crown_base_height=np.array([10.0, 5.0]),
+            height=np.array([20.0, 15.0]),
+            max_crown_radius=np.array([3.0, 2.0]),
+        )
+        z = np.linspace(0, 25, 30)
+        r = model.get_radius_at_height(z)
+        assert r.shape == (2, len(z))
+        assert np.all(r <= np.array([[3.0], [2.0]]) + 1e-9)
+
+    def test_zero_length_crown_is_safe(self):
+        model = ConeCrownProfile(
+            crown_base_height=10.0, height=10.0, max_crown_radius=3.0
+        )
+        # No division-by-zero blow-up; a degenerate crown has no interior.
+        r = model.get_radius_at_height(np.linspace(0, 20, 10))
+        assert np.all(np.isfinite(r))

--- a/tests/crown_profile_models/test_cylinder.py
+++ b/tests/crown_profile_models/test_cylinder.py
@@ -1,0 +1,64 @@
+"""
+tests/crown_profile_models/test_cylinder.py
+"""
+
+# Internal imports
+from fastfuels_core.crown_profile_models.cylinder import CylinderCrownProfile
+
+# External imports
+import numpy as np
+import pytest
+
+HB, HT, R = 10.0, 20.0, 3.0
+
+
+@pytest.fixture
+def model():
+    return CylinderCrownProfile(crown_base_height=HB, height=HT, max_crown_radius=R)
+
+
+class TestGetMaxRadius:
+    def test_returns_r(self, model):
+        assert model.get_max_radius() == pytest.approx(R)
+
+    def test_max_radius_height_is_midpoint(self, model):
+        # Radius is uniform, so the representative height is the crown midpoint.
+        assert model.get_max_radius_height() == pytest.approx((HB + HT) / 2)
+
+
+class TestGetRadiusAtHeight:
+    def test_uniform_within_crown(self, model):
+        z = np.linspace(HB, HT, 50)
+        assert np.allclose(model.get_radius_at_height(z), R)
+
+    def test_at_base_and_top(self, model):
+        assert model.get_radius_at_height(HB) == pytest.approx(R)
+        assert model.get_radius_at_height(HT) == pytest.approx(R)
+
+    def test_outside_crown_is_zero(self, model):
+        assert model.get_radius_at_height(HB - 1.0) == 0.0
+        assert model.get_radius_at_height(HT + 1.0) == 0.0
+        assert model.get_radius_at_height(-5.0) == 0.0
+        assert model.get_radius_at_height(1e6) == 0.0
+
+    def test_scalar_returns_float(self, model):
+        assert isinstance(model.get_radius_at_height(15.0), float)
+
+    def test_1d_returns_1d(self, model):
+        z = np.linspace(HB, HT, 20)
+        r = model.get_radius_at_height(z)
+        assert isinstance(r, np.ndarray)
+        assert r.shape == z.shape
+
+    def test_multiple_trees_returns_2d(self):
+        model = CylinderCrownProfile(
+            crown_base_height=np.array([10.0, 5.0]),
+            height=np.array([20.0, 15.0]),
+            max_crown_radius=np.array([3.0, 2.0]),
+        )
+        z = np.linspace(0, 25, 30)
+        r = model.get_radius_at_height(z)
+        assert r.shape == (2, len(z))
+        # Within each crown the radius equals that tree's R.
+        assert r[0].max() == pytest.approx(3.0)
+        assert r[1].max() == pytest.approx(2.0)

--- a/tests/crown_profile_models/test_ellipsoid.py
+++ b/tests/crown_profile_models/test_ellipsoid.py
@@ -1,0 +1,117 @@
+"""
+tests/crown_profile_models/test_ellipsoid.py
+"""
+
+# Internal imports
+from fastfuels_core.crown_profile_models.ellipsoid import EllipsoidCrownProfile
+
+# External imports
+import numpy as np
+import pytest
+
+HB, HT, R = 10.0, 20.0, 3.0
+MID = (HB + HT) / 2.0
+
+
+@pytest.fixture
+def model():
+    # Hd omitted -> defaults to the crown midpoint (symmetric spheroid).
+    return EllipsoidCrownProfile(crown_base_height=HB, height=HT, max_crown_radius=R)
+
+
+class TestConstruction:
+    def test_default_hd_is_midpoint(self, model):
+        assert model.max_crown_diameter_height.item() == pytest.approx(MID)
+
+    def test_out_of_range_hd_raises(self):
+        with pytest.raises(ValueError):
+            EllipsoidCrownProfile(HB, HT, R, max_crown_diameter_height=HB - 1.0)
+        with pytest.raises(ValueError):
+            EllipsoidCrownProfile(HB, HT, R, max_crown_diameter_height=HT + 1.0)
+
+
+class TestGetMaxRadius:
+    def test_returns_r(self, model):
+        assert model.get_max_radius() == pytest.approx(R)
+
+    def test_max_radius_height_is_hd(self):
+        m = EllipsoidCrownProfile(HB, HT, R, max_crown_diameter_height=13.0)
+        assert m.get_max_radius_height() == pytest.approx(13.0)
+
+
+class TestGetRadiusAtHeight:
+    def test_peak_at_hd(self, model):
+        assert model.get_radius_at_height(MID) == pytest.approx(R)
+
+    def test_zero_at_ends(self, model):
+        assert model.get_radius_at_height(HB) == pytest.approx(0.0)
+        assert model.get_radius_at_height(HT) == pytest.approx(0.0)
+
+    def test_matches_ellipse_formula(self, model):
+        z = np.linspace(HB, HT, 101)
+        hd = MID
+        lower = R * np.sqrt(np.clip(1 - ((hd - z) / (hd - HB)) ** 2, 0, 1))
+        upper = R * np.sqrt(np.clip(1 - ((z - hd) / (HT - hd)) ** 2, 0, 1))
+        expected = np.where(z <= hd, lower, upper)
+        assert np.allclose(model.get_radius_at_height(z), expected)
+
+    def test_spheroid_symmetry_when_hd_is_midpoint(self, model):
+        for s in [1.0, 2.0, 3.0, 4.9]:
+            assert model.get_radius_at_height(MID - s) == pytest.approx(
+                model.get_radius_at_height(MID + s)
+            )
+
+    def test_argmax_coincides_with_hd(self):
+        m = EllipsoidCrownProfile(HB, HT, R, max_crown_diameter_height=13.0)
+        z = np.linspace(HB, HT, 1001)
+        r = m.get_radius_at_height(z)
+        assert z[np.argmax(r)] == pytest.approx(13.0, abs=0.05)
+
+    def test_outside_crown_is_zero(self, model):
+        assert model.get_radius_at_height(HB - 1.0) == 0.0
+        assert model.get_radius_at_height(HT + 1.0) == 0.0
+        assert model.get_radius_at_height(-5.0) == 0.0
+        assert model.get_radius_at_height(1e6) == 0.0
+
+    # ── Single-lobe limiting cases ────────────────────────────────────────
+    def test_single_lobe_widest_at_base(self):
+        m = EllipsoidCrownProfile(HB, HT, R, max_crown_diameter_height=HB)
+        assert m.get_radius_at_height(HB) == pytest.approx(R)
+        assert m.get_radius_at_height(HT) == pytest.approx(0.0)
+        z = np.linspace(HB, HT, 50)
+        r = m.get_radius_at_height(z)
+        assert np.all(np.diff(r) <= 1e-9)
+        assert np.all(np.isfinite(r))
+
+    def test_single_lobe_widest_at_top(self):
+        m = EllipsoidCrownProfile(HB, HT, R, max_crown_diameter_height=HT)
+        assert m.get_radius_at_height(HT) == pytest.approx(R)
+        assert m.get_radius_at_height(HB) == pytest.approx(0.0)
+        z = np.linspace(HB, HT, 50)
+        r = m.get_radius_at_height(z)
+        assert np.all(np.diff(r) >= -1e-9)
+        assert np.all(np.isfinite(r))
+
+    # ── Return shapes ─────────────────────────────────────────────────────
+    def test_scalar_returns_float(self, model):
+        assert isinstance(model.get_radius_at_height(15.0), float)
+
+    def test_1d_returns_1d(self, model):
+        z = np.linspace(HB, HT, 20)
+        r = model.get_radius_at_height(z)
+        assert isinstance(r, np.ndarray)
+        assert r.shape == z.shape
+        assert np.all(r >= 0.0)
+        assert np.all(r <= R + 1e-9)
+
+    def test_multiple_trees_returns_2d(self):
+        model = EllipsoidCrownProfile(
+            crown_base_height=np.array([10.0, 5.0]),
+            height=np.array([20.0, 15.0]),
+            max_crown_radius=np.array([3.0, 2.0]),
+            max_crown_diameter_height=np.array([15.0, 10.0]),
+        )
+        z = np.linspace(0, 25, 30)
+        r = model.get_radius_at_height(z)
+        assert r.shape == (2, len(z))
+        assert np.all(r <= np.array([[3.0], [2.0]]) + 1e-9)

--- a/tests/crown_profile_models/test_paraboloid.py
+++ b/tests/crown_profile_models/test_paraboloid.py
@@ -1,0 +1,118 @@
+"""
+tests/crown_profile_models/test_paraboloid.py
+"""
+
+# Internal imports
+from fastfuels_core.crown_profile_models.paraboloid import ParaboloidCrownProfile
+
+# External imports
+import numpy as np
+import pytest
+
+HB, HT, R = 10.0, 20.0, 3.0
+MID = (HB + HT) / 2.0
+
+
+@pytest.fixture
+def model():
+    # Hd omitted -> defaults to the crown midpoint.
+    return ParaboloidCrownProfile(crown_base_height=HB, height=HT, max_crown_radius=R)
+
+
+class TestConstruction:
+    def test_default_hd_is_midpoint(self, model):
+        assert model.max_crown_diameter_height.item() == pytest.approx(MID)
+
+    def test_out_of_range_hd_raises(self):
+        with pytest.raises(ValueError):
+            ParaboloidCrownProfile(HB, HT, R, max_crown_diameter_height=HB - 1.0)
+        with pytest.raises(ValueError):
+            ParaboloidCrownProfile(HB, HT, R, max_crown_diameter_height=HT + 1.0)
+
+
+class TestGetMaxRadius:
+    def test_returns_r(self, model):
+        assert model.get_max_radius() == pytest.approx(R)
+
+    def test_max_radius_height_is_hd(self):
+        m = ParaboloidCrownProfile(HB, HT, R, max_crown_diameter_height=13.0)
+        assert m.get_max_radius_height() == pytest.approx(13.0)
+
+
+class TestGetRadiusAtHeight:
+    def test_peak_at_hd(self, model):
+        assert model.get_radius_at_height(MID) == pytest.approx(R)
+
+    def test_zero_at_ends(self, model):
+        assert model.get_radius_at_height(HB) == pytest.approx(0.0)
+        assert model.get_radius_at_height(HT) == pytest.approx(0.0)
+
+    def test_matches_sqrt_formula(self, model):
+        z = np.linspace(HB, HT, 101)
+        hd = MID
+        lower = R * np.sqrt(np.clip((z - HB) / (hd - HB), 0, 1))
+        upper = R * np.sqrt(np.clip((HT - z) / (HT - hd), 0, 1))
+        expected = np.where(z <= hd, lower, upper)
+        assert np.allclose(model.get_radius_at_height(z), expected)
+
+    def test_symmetric_when_hd_is_midpoint(self, model):
+        for s in [1.0, 2.0, 3.0, 4.9]:
+            assert model.get_radius_at_height(MID - s) == pytest.approx(
+                model.get_radius_at_height(MID + s)
+            )
+
+    def test_argmax_coincides_with_hd(self):
+        m = ParaboloidCrownProfile(HB, HT, R, max_crown_diameter_height=13.0)
+        z = np.linspace(HB, HT, 1001)
+        r = m.get_radius_at_height(z)
+        assert z[np.argmax(r)] == pytest.approx(13.0, abs=0.05)
+
+    def test_outside_crown_is_zero(self, model):
+        assert model.get_radius_at_height(HB - 1.0) == 0.0
+        assert model.get_radius_at_height(HT + 1.0) == 0.0
+        assert model.get_radius_at_height(-5.0) == 0.0
+        assert model.get_radius_at_height(1e6) == 0.0
+
+    # ── Single-lobe limiting cases ────────────────────────────────────────
+    def test_single_lobe_widest_at_base(self):
+        m = ParaboloidCrownProfile(HB, HT, R, max_crown_diameter_height=HB)
+        assert m.get_radius_at_height(HB) == pytest.approx(R)
+        assert m.get_radius_at_height(HT) == pytest.approx(0.0)
+        # monotonically decreasing from base to top
+        z = np.linspace(HB, HT, 50)
+        r = m.get_radius_at_height(z)
+        assert np.all(np.diff(r) <= 1e-9)
+        assert np.all(np.isfinite(r))
+
+    def test_single_lobe_widest_at_top(self):
+        m = ParaboloidCrownProfile(HB, HT, R, max_crown_diameter_height=HT)
+        assert m.get_radius_at_height(HT) == pytest.approx(R)
+        assert m.get_radius_at_height(HB) == pytest.approx(0.0)
+        z = np.linspace(HB, HT, 50)
+        r = m.get_radius_at_height(z)
+        assert np.all(np.diff(r) >= -1e-9)
+        assert np.all(np.isfinite(r))
+
+    # ── Return shapes ─────────────────────────────────────────────────────
+    def test_scalar_returns_float(self, model):
+        assert isinstance(model.get_radius_at_height(15.0), float)
+
+    def test_1d_returns_1d(self, model):
+        z = np.linspace(HB, HT, 20)
+        r = model.get_radius_at_height(z)
+        assert isinstance(r, np.ndarray)
+        assert r.shape == z.shape
+        assert np.all(r >= 0.0)
+        assert np.all(r <= R + 1e-9)
+
+    def test_multiple_trees_returns_2d(self):
+        model = ParaboloidCrownProfile(
+            crown_base_height=np.array([10.0, 5.0]),
+            height=np.array([20.0, 15.0]),
+            max_crown_radius=np.array([3.0, 2.0]),
+            max_crown_diameter_height=np.array([15.0, 10.0]),
+        )
+        z = np.linspace(0, 25, 30)
+        r = model.get_radius_at_height(z)
+        assert r.shape == (2, len(z))
+        assert np.all(r <= np.array([[3.0], [2.0]]) + 1e-9)

--- a/tests/crown_profile_models/test_purves.py
+++ b/tests/crown_profile_models/test_purves.py
@@ -280,3 +280,21 @@ class TestGetRadiusAtHeight:
         assert np.all(radii >= 0.0)
         assert np.all(radii <= max_radii.reshape(-1, 1))
         assert np.any(radii > 0.0)
+
+
+class TestGetMaxRadiusHeight:
+    def test_returns_crown_base_height(self):
+        # Purves is monotonic, widest at the crown base.
+        # species 122, height=15, crown_ratio=0.5 -> crown_base_height = 7.5
+        model = PurvesCrownProfile(
+            species_code=122, dbh=25.0, height=15.0, crown_ratio=0.5
+        )
+        assert model.get_max_radius_height() == pytest.approx(7.5)
+
+    def test_coincides_with_argmax(self):
+        model = PurvesCrownProfile(
+            species_code=122, dbh=25.0, height=15.0, crown_ratio=0.5
+        )
+        z = np.linspace(7.5, 15.0, 10001)
+        r = model.get_radius_at_height(z)
+        assert z[np.argmax(r)] == pytest.approx(model.get_max_radius_height(), abs=0.01)

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -12,6 +12,10 @@ from fastfuels_core.trees import (
     REF_TRY_DB_LEAF,
 )
 from fastfuels_core.crown_profile_models.beta import BetaCrownProfile
+from fastfuels_core.crown_profile_models.cone import ConeCrownProfile
+from fastfuels_core.crown_profile_models.cylinder import CylinderCrownProfile
+from fastfuels_core.crown_profile_models.paraboloid import ParaboloidCrownProfile
+from fastfuels_core.crown_profile_models.ellipsoid import EllipsoidCrownProfile
 from tests.utils import make_random_tree
 
 # External imports
@@ -668,3 +672,97 @@ class TestFromRowDataFrame:
             tree = Tree.from_row(row)
             assert tree.foliage_biomass == 10.0
             assert tree.max_crown_radius == 3.5
+
+
+class TestGeometricCrownProfiles:
+    """Tests for the geometric crown profile types on Tree (issue #76)."""
+
+    TREE_KWARGS = dict(
+        species_code=122, status_code=1, diameter=25.0, height=15.0, crown_ratio=0.5
+    )
+    # crown_base_height = 15 - 15*0.5 = 7.5; height = 15; midpoint = 11.25
+    HB, HT, MID = 7.5, 15.0, 11.25
+
+    GEOMETRIC = [
+        ("cone", ConeCrownProfile),
+        ("cylinder", CylinderCrownProfile),
+        ("paraboloid", ParaboloidCrownProfile),
+        ("ellipsoid", EllipsoidCrownProfile),
+    ]
+
+    @pytest.mark.parametrize("profile_type,cls", GEOMETRIC)
+    def test_factory_builds_expected_model(self, profile_type, cls):
+        tree = Tree(
+            **self.TREE_KWARGS,
+            crown_profile_model_type=profile_type,
+            max_crown_radius=3.0,
+        )
+        assert isinstance(tree.crown_profile_model, cls)
+
+    @pytest.mark.parametrize("profile_type,_cls", GEOMETRIC)
+    def test_requires_max_crown_radius(self, profile_type, _cls):
+        with pytest.raises(ValueError):
+            Tree(**self.TREE_KWARGS, crown_profile_model_type=profile_type)
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            Tree(**self.TREE_KWARGS, crown_profile_model_type="pyramid")
+
+    @pytest.mark.parametrize("profile_type,_cls", GEOMETRIC)
+    def test_max_crown_radius_used_directly(self, profile_type, _cls):
+        tree = Tree(
+            **self.TREE_KWARGS,
+            crown_profile_model_type=profile_type,
+            max_crown_radius=3.0,
+        )
+        assert tree.max_crown_radius == pytest.approx(3.0)
+        assert tree._crown_radius_scale_factor == pytest.approx(1.0)
+
+    @pytest.mark.parametrize("profile_type,_cls", GEOMETRIC)
+    def test_get_crown_radius_matches_profile(self, profile_type, _cls):
+        tree = Tree(
+            **self.TREE_KWARGS,
+            crown_profile_model_type=profile_type,
+            max_crown_radius=3.0,
+        )
+        z = np.linspace(0.0, 16.0, 40)
+        assert np.allclose(
+            tree.get_crown_radius_at_height(z),
+            tree.crown_profile_model.get_radius_at_height(z),
+        )
+
+    def test_max_crown_diameter_height_defaults_to_midpoint(self):
+        tree = Tree(
+            **self.TREE_KWARGS,
+            crown_profile_model_type="paraboloid",
+            max_crown_radius=3.0,
+        )
+        assert tree.get_crown_radius_at_height(self.MID) == pytest.approx(3.0)
+
+    def test_max_crown_diameter_height_moves_peak(self):
+        hd = 9.0
+        tree = Tree(
+            **self.TREE_KWARGS,
+            crown_profile_model_type="ellipsoid",
+            max_crown_radius=3.0,
+            max_crown_diameter_height=hd,
+        )
+        assert tree.get_crown_radius_at_height(hd) == pytest.approx(3.0)
+        assert tree.get_crown_radius_at_height(self.MID) < 3.0
+
+    def test_lanl_reproduction_recipe(self):
+        # Decoupled, opt-in: derive Hd from the beta profile mode and pass it in.
+        cbh = self.HT - self.HT * 0.5
+        cl = self.HT * 0.5
+        beta = BetaCrownProfile(
+            species_code=122, crown_base_height=cbh, crown_length=cl
+        )
+        hd = beta.get_max_radius_height()
+        assert cbh <= hd <= cbh + cl
+        tree = Tree(
+            **self.TREE_KWARGS,
+            crown_profile_model_type="paraboloid",
+            max_crown_radius=3.0,
+            max_crown_diameter_height=hd,
+        )
+        assert tree.get_crown_radius_at_height(hd) == pytest.approx(3.0)


### PR DESCRIPTION
Closes #76.

Adds four deterministic geometric crown profiles selectable through the existing `Tree(crown_profile_model_type=...)` API — "Axis A" (crown shape / occupancy envelope). Mass magnitude/distribution is out of scope.

## New profiles
Each is a rotational solid defined by `R(z)` between the crown base `Hb` and tree top `Ht`, with `R = max_crown_radius`:

- **cone** — `R(z) = R·(Ht−z)/(Ht−Hb)`, widest at the crown base (single cone)
- **cylinder** — `R(z) = R`, uniform
- **paraboloid** — double paraboloid peaking at `Hd` (`max_crown_diameter_height`)
- **ellipsoid** — double half-ellipsoid peaking at `Hd` (a symmetric spheroid when `Hd` is the midpoint)

Each is a standalone `CrownProfileModel` subclass (mirroring `purves.py`/`beta.py`) with vectorized `get_radius_at_height` / `get_max_radius`.

## Design notes
- **`max_crown_diameter_height`** is a new optional `Tree` parameter, used only by paraboloid/ellipsoid to place the peak; defaults to the crown midpoint. Validated to lie within `[Hb, Ht]`.
- **Single-lobe shapes come for free**: a single paraboloid/ellipsoid is the limiting case `Hd == Hb` (widest at base) or `Hd == Ht` (widest at top); degenerate lobes are handled safely (no NaN warnings).
- **`max_crown_radius` is mandatory** for the geometric profiles and is the defining radius. The existing override plumbing is a no-op here because `get_max_radius()` returns `R`, so the scale factor is `R/R = 1.0` — no changes needed to `get_crown_radius_at_height`.
- **`get_max_radius_height()`** added to every profile (the height of maximum radius): beta → distribution mode, purves/cone → crown base, paraboloid/ellipsoid → `Hd`, cylinder → midpoint (radius is uniform). Kept off the ABC.
- **LANL Trees reproduction** stays opt-in and decoupled. The paraboloid envelope is algebraically identical to the LANL Trees double paraboloid, which places its peak at the **beta-profile mode**. Callers reproduce it explicitly:
  ```python
  hd = BetaCrownProfile(species_code, crown_base_height, crown_length).get_max_radius_height()
  Tree(..., crown_profile_model_type="paraboloid", max_crown_radius=R, max_crown_diameter_height=hd)
  ```

## Out of scope
- Crown mass magnitude and vertical distribution (tracked separately).
- Voxelization stochastic-sampler bypass for geometric profiles — `voxelization.py` is unchanged.

## Testing
- New unit tests for each profile: radius at key heights, the sqrt/ellipse formulas, single-lobe limiting cases, out-of-range `Hd` raising, and scalar/1D/2D return shapes.
- `Tree` integration tests: factory wiring, invalid type + missing `max_crown_radius` raising, scale factor `== 1.0`, `Hd` default/override, and the LANL recipe.
- `get_max_radius_height()` tests for beta and purves (coincide with the radius argmax).
- Full suite green (25,452 passed); pre-commit (black, flake8) clean.
