### PR TITLE
Clean up test workflow: uv, Python 3.13 only, quiet pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,10 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout Repository
@@ -18,10 +14,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
         cache: pip
 
     - name: Install package with test dependencies
@@ -30,4 +26,4 @@ jobs:
         pip install -e .[test]
 
     - name: Run pytest
-      run: pytest
+      run: pytest -q

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,16 +14,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.13"
-        cache: pip
+        enable-cache: true
 
     - name: Install package with test dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[test]
+      run: uv sync --extra test
 
     - name: Run pytest
-      run: pytest -q
+      run: uv run --extra test pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,12 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
+# uv
+#   uv.lock pins the full dependency tree for a specific environment. It is not
+#   shipped in the distribution and is not used by downstream consumers, so for
+#   a library it is generally not committed; CI resolves dependencies fresh.
+uv.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 


### PR DESCRIPTION
Cleans up `.github/workflows/run-tests.yml`:

- **Use uv** — replace the `setup-python` + `pip install -e .[test]` steps with `astral-sh/setup-uv` (which also provisions Python 3.13), then `uv sync --extra test` and `uv run --extra test pytest -q`, for parity with local development.
- **Drop the test matrix** — run tests only on Python 3.13 instead of the `3.10`–`3.13` matrix.
- **Quieter pytest** — `-q` to reduce runner log volume.

Dependencies are resolved fresh (no committed `uv.lock`), matching the prior pip behavior. `uv.lock` is a per-environment artifact that isn't shipped in the distribution and isn't used by downstream consumers, so for a library it's left uncommitted and added to `.gitignore`. Verified locally: the full suite passes under `uv run --extra test pytest -q` (exit 0).
