### PR TITLE
Add CLAUDE.md with repository conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Git commits
+
+- Do **not** add a "Co-Authored-By: Claude" line, or any similar AI sign-off or
+  attribution, to commit messages or pull request descriptions.
+
+## Package management
+
+- This project uses `uv`, not pip. Run tools through uv, e.g. `uv run pytest`,
+  and manage dependencies with `uv sync` / `uv add`.


### PR DESCRIPTION
Adds a `CLAUDE.md` documenting two conventions for Claude Code in this repo:

- **No AI sign-offs** — commit messages and PR descriptions must not include a `Co-Authored-By: Claude` line (or any similar attribution).
- **uv for package management** — run tools via `uv` (e.g. `uv run pytest`).