### PR TITLE
Refactor voxelization.py into a voxelization/ package

### DIFF
--- a/fastfuels_core/voxelization/__init__.py
+++ b/fastfuels_core/voxelization/__init__.py
@@ -1,0 +1,18 @@
+"""Voxelization of tree crowns into volume-fraction / occupancy grids.
+
+Public API is re-exported here; the implementation is split across
+``_coords`` (grid coordinates), ``marching_squares`` (volume-fraction
+discretization), ``sampling`` (stochastic occupancy realization), and
+``tree`` (the ``VoxelizedTree`` / ``voxelize_tree`` orchestration).
+"""
+
+from fastfuels_core.voxelization._coords import CenteringMode
+from fastfuels_core.voxelization.marching_squares import discretize_crown_profile
+from fastfuels_core.voxelization.tree import VoxelizedTree, voxelize_tree
+
+__all__ = [
+    "VoxelizedTree",
+    "voxelize_tree",
+    "CenteringMode",
+    "discretize_crown_profile",
+]

--- a/fastfuels_core/voxelization/_coords.py
+++ b/fastfuels_core/voxelization/_coords.py
@@ -1,0 +1,69 @@
+# Core imports
+from __future__ import annotations
+from typing import Literal
+
+# External imports
+import numpy as np
+from numpy import ndarray
+
+# Type definitions
+CenteringMode = Literal["cell", "vertex"]
+
+
+def _get_vertical_tree_coords(step, tree_height, crown_base_height):
+    """
+    Returns a grid of coordinates for a tree of height, height, with a spacing
+    step. The grid is returned as a 1D array.
+    """
+    grid = np.arange(crown_base_height, tree_height + step, step)
+    return grid
+
+
+def _get_horizontal_tree_coords(
+    step, radius, pos=0.0, centering: CenteringMode = "cell"
+):
+    """
+    Discretizes a stem position and crown radius into a 1D array of coordinates.
+
+    Parameters
+    ----------
+    step : float
+        Grid cell size (resolution)
+    radius : float
+        Crown radius to cover
+    pos : float
+        Position of tree stem (default 0.0)
+    centering : {"cell", "vertex"}
+        - "cell": Grid has odd number of cells, stem at center of middle cell
+        - "vertex": Grid has even number of cells, stem at vertex between cells
+    """
+    cells_per_side = int(np.floor(np.abs(radius / step))) + 1
+
+    if centering == "cell":
+        # Odd grid: stem at cell center
+        lower_bound = pos - cells_per_side * step
+        upper_bound = pos + cells_per_side * step
+        grid = np.linspace(lower_bound, upper_bound, 2 * cells_per_side + 1)
+    else:  # vertex
+        # Even grid: stem at vertex (cell centers offset by half-step)
+        lower_bound = pos - (cells_per_side - 0.5) * step
+        upper_bound = pos + (cells_per_side - 0.5) * step
+        grid = np.linspace(lower_bound, upper_bound, 2 * cells_per_side)
+
+    return grid
+
+
+def _resample_coords_grid_to_subgrid(
+    grid: ndarray, grid_spacing: float, new_spacing: float
+) -> ndarray:
+    """
+    Resamples grid with spacing grid_spacing to a subgrid with spacing
+    new_spacing.
+    """
+    subgrid = np.arange(
+        grid[0] - grid_spacing / 2 + new_spacing / 2,
+        grid[-1] + grid_spacing / 2,
+        new_spacing,
+    )
+
+    return subgrid

--- a/fastfuels_core/voxelization/marching_squares.py
+++ b/fastfuels_core/voxelization/marching_squares.py
@@ -1,66 +1,22 @@
 # Core imports
 from __future__ import annotations
 import math
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 # Internal imports
+from fastfuels_core.voxelization._coords import (
+    CenteringMode,
+    _get_horizontal_tree_coords,
+    _get_vertical_tree_coords,
+    _resample_coords_grid_to_subgrid,
+)
+
 if TYPE_CHECKING:
     from fastfuels_core.trees import Tree
 
 # External imports
 import numpy as np
 from numpy import ndarray
-from scipy.ndimage import distance_transform_edt
-
-# Type definitions
-CenteringMode = Literal["cell", "vertex"]
-
-
-class VoxelizedTree:
-    def __init__(
-        self, tree: "Tree", grid: ndarray, hr, vr, centering: CenteringMode = "cell"
-    ):
-        self.tree = tree
-        self.grid = grid
-        self.hr = hr
-        self.vr = vr
-        self.centering = centering
-
-    def distribute_biomass(self):
-        volume = np.sum(self.grid) * self.hr * self.hr * self.vr
-        foliage_mpv = self.tree.foliage_biomass / volume
-        biomass_grid = self.grid.copy() * foliage_mpv
-        return biomass_grid
-
-
-def voxelize_tree(
-    tree: "Tree",
-    horizontal_resolution: float,
-    vertical_resolution: float,
-    centering: CenteringMode = "cell",
-    **kwargs,
-) -> VoxelizedTree:
-
-    vr_subgrid = kwargs.get("vr_subgrid", 0.1)
-    crown_profile_mask = discretize_crown_profile(
-        tree,
-        horizontal_resolution,
-        vertical_resolution,
-        centering=centering,
-        vr_subgrid=vr_subgrid,
-    )
-
-    alpha = kwargs.get("alpha", 0.5)
-    beta = kwargs.get("beta", 0.5)
-    rho = kwargs.get("rho", None)
-    seed = kwargs.get("seed", None)
-
-    sampled_crown_mask = sample_occupied_cells(
-        crown_profile_mask, alpha, beta, rho, seed
-    )
-    return VoxelizedTree(
-        tree, sampled_crown_mask, horizontal_resolution, vertical_resolution, centering
-    )
 
 
 def discretize_crown_profile(
@@ -100,49 +56,6 @@ def discretize_crown_profile(
     return _align_quadrants(q1_grid, q2_grid, q3_grid, q4_grid, centering=centering)
 
 
-def _get_vertical_tree_coords(step, tree_height, crown_base_height):
-    """
-    Returns a grid of coordinates for a tree of height, height, with a spacing
-    step. The grid is returned as a 1D array.
-    """
-    grid = np.arange(crown_base_height, tree_height + step, step)
-    return grid
-
-
-def _get_horizontal_tree_coords(
-    step, radius, pos=0.0, centering: CenteringMode = "cell"
-):
-    """
-    Discretizes a stem position and crown radius into a 1D array of coordinates.
-
-    Parameters
-    ----------
-    step : float
-        Grid cell size (resolution)
-    radius : float
-        Crown radius to cover
-    pos : float
-        Position of tree stem (default 0.0)
-    centering : {"cell", "vertex"}
-        - "cell": Grid has odd number of cells, stem at center of middle cell
-        - "vertex": Grid has even number of cells, stem at vertex between cells
-    """
-    cells_per_side = int(np.floor(np.abs(radius / step))) + 1
-
-    if centering == "cell":
-        # Odd grid: stem at cell center
-        lower_bound = pos - cells_per_side * step
-        upper_bound = pos + cells_per_side * step
-        grid = np.linspace(lower_bound, upper_bound, 2 * cells_per_side + 1)
-    else:  # vertex
-        # Even grid: stem at vertex (cell centers offset by half-step)
-        lower_bound = pos - (cells_per_side - 0.5) * step
-        upper_bound = pos + (cells_per_side - 0.5) * step
-        grid = np.linspace(lower_bound, upper_bound, 2 * cells_per_side)
-
-    return grid
-
-
 def _discretize_crown_profile_quadrant(
     tree: "Tree",
     x_pts,
@@ -174,22 +87,6 @@ def _discretize_crown_profile_quadrant(
     volume_fraction = np.minimum(volume / (hr * hr * vr), 1.0)
 
     return volume_fraction
-
-
-def _resample_coords_grid_to_subgrid(
-    grid: ndarray, grid_spacing: float, new_spacing: float
-) -> ndarray:
-    """
-    Resamples grid with spacing grid_spacing to a subgrid with spacing
-    new_spacing.
-    """
-    subgrid = np.arange(
-        grid[0] - grid_spacing / 2 + new_spacing / 2,
-        grid[-1] + grid_spacing / 2,
-        new_spacing,
-    )
-
-    return subgrid
 
 
 def _compute_intersection_area(
@@ -591,139 +488,3 @@ def _align_quadrants(q1, q2, q3, q4, centering: CenteringMode = "cell"):
         grid[:, mid_y:, :mid_x] = q4
 
     return grid
-
-
-def sample_occupied_cells(
-    volume_fraction_array: ndarray,
-    alpha: float,
-    beta: float,
-    rho: float = None,
-    seed: int = None,
-) -> ndarray:
-    # Create a probability mask for the crown grid
-    mask_bool = np.where(volume_fraction_array > 0.0, 1.0, 0.0)
-    mask_prob = _compute_joint_probability(mask_bool, alpha, beta)
-
-    # Choose n voxels from the joint probability grid
-    if rho is None:
-        rho = _estimate_crown_density(np.sum(mask_bool))
-    n = int(np.count_nonzero(mask_bool) * rho)
-    sampled = _sample_voxels_from_probability_grid(n, mask_prob, seed)
-
-    # Make non-zero selected voxels 1
-    selected = np.where(sampled > 0, 1.0, 0.0)
-
-    return selected * volume_fraction_array
-
-
-def _compute_joint_probability(mask: ndarray, alpha: float, beta: float) -> ndarray:
-    """
-    Combines the horizontal and vertical probability spatial to create a joint
-    probability grid for the crown mask.
-    """
-    # Build the horizontal and vertical probability spatial
-    horizontal_probability = _compute_horizontal_probability(mask, alpha)
-    vertical_probability = _compute_vertical_probability(mask, beta)
-
-    # Combine the probability spatial for joint probability
-    joint_probability = horizontal_probability * vertical_probability
-    joint_probability /= np.max(joint_probability)
-
-    return joint_probability
-
-
-def _compute_horizontal_probability(mask: ndarray, alpha: float) -> ndarray:
-    """
-    Builds a horizontal probability grid from a binary mask using a Euclidean
-    Distance Transform (EDT). The function computes the EDT of the input
-    mask, inverts the EDT values by subtracting them from the maximum value,
-    applies a power function using the alpha parameter, and finally
-    normalizes the result. Any NaN values in the final probability grid are
-    replaced with 0.
-    """
-    # Compute the Euclidean Distance Transform (EDT) of the mask
-    edt = distance_transform_edt(mask)
-
-    # Inverse the distance transform
-    # Add a small value to avoid zero probabilities
-    max_dist = np.max(edt) + 1e-6
-    edt = max_dist - edt
-    edt[edt == max_dist] = 0
-
-    # Apply the alpha parameter
-    edt = np.nan_to_num(mask * edt**alpha)
-
-    # Normalize and replace nans with 0
-    horizontal_probability = edt / np.max(edt)
-    horizontal_probability = np.nan_to_num(horizontal_probability)
-
-    return horizontal_probability
-
-
-def _compute_vertical_probability(mask: ndarray, beta: float) -> ndarray:
-    """
-    Builds a vertical probability grid from a binary mask. The function
-    computes a 1D grid along the vertical axis (axis=2) of the input mask,
-    raises this grid to the power of beta, and then broadcasts this
-    transformed grid across the 2D plane of each layer of the mask (along
-    axis=0 and axis=1), and multiplies it with the mask. Finally, the result
-    is normalized and any NaN values are replaced with 0.
-    """
-    # Create a grid for the vertical axis (axis=2)
-    z_grid = np.arange(mask.shape[0]).astype(float)
-
-    # Compute the power of the vertical axis grid with beta
-    z_power_beta = z_grid**beta
-
-    # Add a small value to avoid zero probabilities
-    z_power_beta += 0.01
-
-    # Broadcast the vertical probability grid along axis=0 and axis=1
-    vertical_probability = mask * z_power_beta[:, np.newaxis, np.newaxis]
-
-    # Normalize and replace nans with 0
-    vertical_probability /= np.max(vertical_probability)
-    vertical_probability = np.nan_to_num(vertical_probability)
-
-    return vertical_probability
-
-
-def _estimate_crown_density(volume: float, threshold: float = 16) -> float:
-    if volume < threshold:
-        return 1
-    return 0.5
-
-
-def _sample_voxels_from_probability_grid(
-    n: int, joint_probability: ndarray, seed: int = None
-) -> ndarray:
-    """
-    Samples n voxels from the joint probability grid. Sampling is weighted by
-    the joint probability of each voxel, such that voxels with higher joint
-    probability are more likely to be sampled. Voxels are sampled without
-    replacement.
-    """
-    if seed:
-        np.random.seed(seed)
-
-    # If joint probability is all zeros, return an empty array
-    if np.all(joint_probability == 0):
-        return joint_probability
-
-    # Flatten and normalize the joint probability to sum to one
-    jp_flat = joint_probability.flatten()
-    jp_flat = jp_flat / np.sum(jp_flat)
-
-    # If jp_flat contains nan values, return an empty array
-    if np.any(np.isnan(jp_flat)):
-        return joint_probability
-
-    # Choose n indices from the flattened joint probability
-    chosen_indices = np.random.choice(
-        np.arange(joint_probability.size), n, replace=False, p=jp_flat
-    )
-
-    # Build flat selection array and reshape to original shape
-    selected_flat = np.zeros(joint_probability.size)
-    selected_flat[chosen_indices] = jp_flat[chosen_indices]
-    return selected_flat.reshape(joint_probability.shape)

--- a/fastfuels_core/voxelization/sampling.py
+++ b/fastfuels_core/voxelization/sampling.py
@@ -1,0 +1,143 @@
+# Core imports
+from __future__ import annotations
+
+# External imports
+import numpy as np
+from numpy import ndarray
+from scipy.ndimage import distance_transform_edt
+
+
+def sample_occupied_cells(
+    volume_fraction_array: ndarray,
+    alpha: float,
+    beta: float,
+    rho: float = None,
+    seed: int = None,
+) -> ndarray:
+    # Create a probability mask for the crown grid
+    mask_bool = np.where(volume_fraction_array > 0.0, 1.0, 0.0)
+    mask_prob = _compute_joint_probability(mask_bool, alpha, beta)
+
+    # Choose n voxels from the joint probability grid
+    if rho is None:
+        rho = _estimate_crown_density(np.sum(mask_bool))
+    n = int(np.count_nonzero(mask_bool) * rho)
+    sampled = _sample_voxels_from_probability_grid(n, mask_prob, seed)
+
+    # Make non-zero selected voxels 1
+    selected = np.where(sampled > 0, 1.0, 0.0)
+
+    return selected * volume_fraction_array
+
+
+def _compute_joint_probability(mask: ndarray, alpha: float, beta: float) -> ndarray:
+    """
+    Combines the horizontal and vertical probability spatial to create a joint
+    probability grid for the crown mask.
+    """
+    # Build the horizontal and vertical probability spatial
+    horizontal_probability = _compute_horizontal_probability(mask, alpha)
+    vertical_probability = _compute_vertical_probability(mask, beta)
+
+    # Combine the probability spatial for joint probability
+    joint_probability = horizontal_probability * vertical_probability
+    joint_probability /= np.max(joint_probability)
+
+    return joint_probability
+
+
+def _compute_horizontal_probability(mask: ndarray, alpha: float) -> ndarray:
+    """
+    Builds a horizontal probability grid from a binary mask using a Euclidean
+    Distance Transform (EDT). The function computes the EDT of the input
+    mask, inverts the EDT values by subtracting them from the maximum value,
+    applies a power function using the alpha parameter, and finally
+    normalizes the result. Any NaN values in the final probability grid are
+    replaced with 0.
+    """
+    # Compute the Euclidean Distance Transform (EDT) of the mask
+    edt = distance_transform_edt(mask)
+
+    # Inverse the distance transform
+    # Add a small value to avoid zero probabilities
+    max_dist = np.max(edt) + 1e-6
+    edt = max_dist - edt
+    edt[edt == max_dist] = 0
+
+    # Apply the alpha parameter
+    edt = np.nan_to_num(mask * edt**alpha)
+
+    # Normalize and replace nans with 0
+    horizontal_probability = edt / np.max(edt)
+    horizontal_probability = np.nan_to_num(horizontal_probability)
+
+    return horizontal_probability
+
+
+def _compute_vertical_probability(mask: ndarray, beta: float) -> ndarray:
+    """
+    Builds a vertical probability grid from a binary mask. The function
+    computes a 1D grid along the vertical axis (axis=2) of the input mask,
+    raises this grid to the power of beta, and then broadcasts this
+    transformed grid across the 2D plane of each layer of the mask (along
+    axis=0 and axis=1), and multiplies it with the mask. Finally, the result
+    is normalized and any NaN values are replaced with 0.
+    """
+    # Create a grid for the vertical axis (axis=2)
+    z_grid = np.arange(mask.shape[0]).astype(float)
+
+    # Compute the power of the vertical axis grid with beta
+    z_power_beta = z_grid**beta
+
+    # Add a small value to avoid zero probabilities
+    z_power_beta += 0.01
+
+    # Broadcast the vertical probability grid along axis=0 and axis=1
+    vertical_probability = mask * z_power_beta[:, np.newaxis, np.newaxis]
+
+    # Normalize and replace nans with 0
+    vertical_probability /= np.max(vertical_probability)
+    vertical_probability = np.nan_to_num(vertical_probability)
+
+    return vertical_probability
+
+
+def _estimate_crown_density(volume: float, threshold: float = 16) -> float:
+    if volume < threshold:
+        return 1
+    return 0.5
+
+
+def _sample_voxels_from_probability_grid(
+    n: int, joint_probability: ndarray, seed: int = None
+) -> ndarray:
+    """
+    Samples n voxels from the joint probability grid. Sampling is weighted by
+    the joint probability of each voxel, such that voxels with higher joint
+    probability are more likely to be sampled. Voxels are sampled without
+    replacement.
+    """
+    if seed:
+        np.random.seed(seed)
+
+    # If joint probability is all zeros, return an empty array
+    if np.all(joint_probability == 0):
+        return joint_probability
+
+    # Flatten and normalize the joint probability to sum to one
+    jp_flat = joint_probability.flatten()
+    jp_flat = jp_flat / np.sum(jp_flat)
+
+    # If jp_flat contains nan values, return an empty array
+    if np.any(np.isnan(jp_flat)):
+        return joint_probability
+
+    # Choose n indices from the flattened joint probability
+    chosen_indices = np.random.choice(
+        np.arange(joint_probability.size), n, replace=False, p=jp_flat
+    )
+
+    # Build flat selection array and reshape to original shape
+    selected_flat = np.zeros(joint_probability.size)
+    selected_flat[chosen_indices] = jp_flat[chosen_indices]
+    return selected_flat.reshape(joint_probability.shape)

--- a/fastfuels_core/voxelization/tree.py
+++ b/fastfuels_core/voxelization/tree.py
@@ -1,0 +1,62 @@
+# Core imports
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+# Internal imports
+from fastfuels_core.voxelization._coords import CenteringMode
+from fastfuels_core.voxelization.marching_squares import discretize_crown_profile
+from fastfuels_core.voxelization.sampling import sample_occupied_cells
+
+if TYPE_CHECKING:
+    from fastfuels_core.trees import Tree
+
+# External imports
+import numpy as np
+from numpy import ndarray
+
+
+class VoxelizedTree:
+    def __init__(
+        self, tree: "Tree", grid: ndarray, hr, vr, centering: CenteringMode = "cell"
+    ):
+        self.tree = tree
+        self.grid = grid
+        self.hr = hr
+        self.vr = vr
+        self.centering = centering
+
+    def distribute_biomass(self):
+        volume = np.sum(self.grid) * self.hr * self.hr * self.vr
+        foliage_mpv = self.tree.foliage_biomass / volume
+        biomass_grid = self.grid.copy() * foliage_mpv
+        return biomass_grid
+
+
+def voxelize_tree(
+    tree: "Tree",
+    horizontal_resolution: float,
+    vertical_resolution: float,
+    centering: CenteringMode = "cell",
+    **kwargs,
+) -> VoxelizedTree:
+
+    vr_subgrid = kwargs.get("vr_subgrid", 0.1)
+    crown_profile_mask = discretize_crown_profile(
+        tree,
+        horizontal_resolution,
+        vertical_resolution,
+        centering=centering,
+        vr_subgrid=vr_subgrid,
+    )
+
+    alpha = kwargs.get("alpha", 0.5)
+    beta = kwargs.get("beta", 0.5)
+    rho = kwargs.get("rho", None)
+    seed = kwargs.get("seed", None)
+
+    sampled_crown_mask = sample_occupied_cells(
+        crown_profile_mask, alpha, beta, rho, seed
+    )
+    return VoxelizedTree(
+        tree, sampled_crown_mask, horizontal_resolution, vertical_resolution, centering
+    )

--- a/tests/test_voxelization.py
+++ b/tests/test_voxelization.py
@@ -7,9 +7,15 @@ from pathlib import Path
 from tests.utils import make_random_tree
 from fastfuels_core.trees import Tree
 from fastfuels_core.voxelization import (
+    discretize_crown_profile,
+    voxelize_tree,
+)
+from fastfuels_core.voxelization._coords import (
     _get_horizontal_tree_coords,
     _get_vertical_tree_coords,
     _resample_coords_grid_to_subgrid,
+)
+from fastfuels_core.voxelization.marching_squares import (
     _compute_circle_segment_area,
     _calculate_case_1_area,
     _calculate_case_3_area,
@@ -20,12 +26,12 @@ from fastfuels_core.voxelization import (
     _compute_intersection_area_by_case,
     _sum_area_along_axis,
     _align_quadrants,
-    discretize_crown_profile,
+)
+from fastfuels_core.voxelization.sampling import (
     _compute_horizontal_probability,
     _compute_vertical_probability,
     _compute_joint_probability,
     _sample_voxels_from_probability_grid,
-    voxelize_tree,
 )
 
 # External imports


### PR DESCRIPTION
Closes #77.

Splits the single `fastfuels_core/voxelization.py` into a `voxelization/` package so a future subgrid backend (configurable mass distributions, separate issue) can sit beside the marching-squares one without duplicating the shared coordinate helpers or orchestration.

**Pure structural move: function bodies are lifted verbatim, no behavior change, no public API change.**

## Layout

```
fastfuels_core/voxelization/
  __init__.py          # thin re-export of the public API (no logic)
  _coords.py           # grid coordinate helpers + CenteringMode
  marching_squares.py  # volume-fraction discretization algorithm
  sampling.py          # stochastic occupancy realization (purves/beta)
  tree.py              # VoxelizedTree + voxelize_tree orchestration
```

`__init__.py` re-exports exactly the four public names (`VoxelizedTree`, `voxelize_tree`, `CenteringMode`, `discretize_crown_profile`); `sample_occupied_cells` stays internal to `sampling.py`.

## Compatibility

- `trees.py` is **unchanged** — `from fastfuels_core.voxelization import VoxelizedTree, voxelize_tree, CenteringMode` still resolves via the re-exports.
- `tests/test_voxelization.py`: only the import block changed — internal helpers now import from their submodules; public names still come from the top-level package. No test bodies changed.
- git tracks the move as a rename of the old file into `marching_squares.py`, preserving history for the largest module.

## Verification

- Import smoke check resolves all public names + `import fastfuels_core.trees`.
- `tests/test_voxelization.py`: 147 passed.
- Full suite: 25,452 passed (identical to pre-refactor).
- `black --check` clean; pre-commit hooks (black, flake8) pass.