### PR TITLE
Composable voxelization: configurable mass distribution + subgrid backend

### DIFF
--- a/fastfuels_core/voxelization/__init__.py
+++ b/fastfuels_core/voxelization/__init__.py
@@ -8,6 +8,13 @@ discretization), ``sampling`` (stochastic occupancy realization), and
 
 from fastfuels_core.voxelization._coords import CenteringMode
 from fastfuels_core.voxelization.marching_squares import discretize_crown_profile
+from fastfuels_core.voxelization.mass_distribution import (
+    DensityField,
+    GradientDensity,
+    LinearHeightQuadraticRadialDensity,
+    UniformDensity,
+)
+from fastfuels_core.voxelization.sampling import sample_occupied_cells
 from fastfuels_core.voxelization.tree import VoxelizedTree, voxelize_tree
 
 __all__ = [
@@ -15,4 +22,9 @@ __all__ = [
     "voxelize_tree",
     "CenteringMode",
     "discretize_crown_profile",
+    "sample_occupied_cells",
+    "DensityField",
+    "UniformDensity",
+    "GradientDensity",
+    "LinearHeightQuadraticRadialDensity",
 ]

--- a/fastfuels_core/voxelization/_coords.py
+++ b/fastfuels_core/voxelization/_coords.py
@@ -10,13 +10,24 @@ from numpy import ndarray
 CenteringMode = Literal["cell", "vertex"]
 
 
-def _get_vertical_tree_coords(step, tree_height, crown_base_height):
+def _get_vertical_tree_coords(step, tree_height, crown_base_height, z_origin=None):
     """
-    Returns a grid of coordinates for a tree of height, height, with a spacing
-    step. The grid is returned as a 1D array.
+    Returns the z cell-center coordinates spanning the crown, spacing ``step``.
+
+    ``z_origin`` controls where the grid is anchored:
+
+    * ``None`` (default): the crown base sits at the *center* of the first cell
+      (cells at ``crown_base_height + k*step``). Self-anchored per tree.
+    * a float: cell *boundaries* align to ``z_origin + k*step`` (centers at
+      ``z_origin + (k + 0.5)*step``), so the crown base falls wherever it lands
+      inside a cell. Use this to register the crown to a shared domain grid
+      (e.g. ``z_origin=ground_elevation``).
     """
-    grid = np.arange(crown_base_height, tree_height + step, step)
-    return grid
+    if z_origin is None:
+        return np.arange(crown_base_height, tree_height + step, step)
+    k_lo = int(np.floor((crown_base_height - z_origin) / step))
+    k_hi = int(np.floor((tree_height - z_origin) / step))
+    return z_origin + (np.arange(k_lo, k_hi + 1) + 0.5) * step
 
 
 def _get_horizontal_tree_coords(
@@ -54,16 +65,16 @@ def _get_horizontal_tree_coords(
 
 
 def _resample_coords_grid_to_subgrid(
-    grid: ndarray, grid_spacing: float, new_spacing: float
+    grid: ndarray, grid_spacing: float, n_subgrid: int
 ) -> ndarray:
     """
-    Resamples grid with spacing grid_spacing to a subgrid with spacing
-    new_spacing.
-    """
-    subgrid = np.arange(
-        grid[0] - grid_spacing / 2 + new_spacing / 2,
-        grid[-1] + grid_spacing / 2,
-        new_spacing,
-    )
+    Split each cell (centered on a point in ``grid``, of width ``grid_spacing``)
+    into ``n_subgrid`` equal subcells and return their centers.
 
-    return subgrid
+    Exact by construction: the result always has ``len(grid) * n_subgrid``
+    points, so it is robust to counts whose implied spacing has no clean float
+    representation (e.g. 3 subcells of 1/3 m).
+    """
+    grid = np.asarray(grid)
+    offsets = (np.arange(n_subgrid) + 0.5) / n_subgrid * grid_spacing - grid_spacing / 2
+    return (grid[:, None] + offsets[None, :]).ravel()

--- a/fastfuels_core/voxelization/marching_squares.py
+++ b/fastfuels_core/voxelization/marching_squares.py
@@ -1,6 +1,5 @@
 # Core imports
 from __future__ import annotations
-import math
 from typing import TYPE_CHECKING
 
 # Internal imports
@@ -25,18 +24,24 @@ def discretize_crown_profile(
     vr: float,
     full_intersection=True,
     centering: CenteringMode = "cell",
-    vr_subgrid: float = 0.1,
+    n_vertical_subgrid: int = 10,
+    z_origin: float = None,
 ) -> ndarray:
-    # Validate that vr_subgrid divides evenly into vr
-    ratio = vr / vr_subgrid
-    if not math.isclose(ratio, round(ratio)):
-        raise ValueError(f"vr_subgrid ({vr_subgrid}) must divide evenly into vr ({vr})")
+    # Each output z-cell is evaluated at n_vertical_subgrid sub-heights to
+    # capture how the crown radius changes over the cell. Marching squares is
+    # exact in the horizontal, so there is no horizontal subgrid; for finer
+    # horizontal detail pass a finer hr.
+    if n_vertical_subgrid < 1:
+        raise ValueError(
+            f"n_vertical_subgrid must be a positive integer, got {n_vertical_subgrid}"
+        )
+    n_vertical_subgrid = int(n_vertical_subgrid)
 
     # Get the horizontal and vertical coordinates of the tree crown
     horizontal_coords = _get_horizontal_tree_coords(
         hr, tree.max_crown_radius, centering=centering
     )
-    z_pts = _get_vertical_tree_coords(vr, tree.height, tree.crown_base_height)
+    z_pts = _get_vertical_tree_coords(vr, tree.height, tree.crown_base_height, z_origin)
 
     # Slice the horizontal coordinates to get the first quadrant of the xy plane
     q2_slice = slice(len(horizontal_coords) // 2, None)
@@ -44,7 +49,7 @@ def discretize_crown_profile(
     y_pts_q2 = np.flip(x_pts_q2)
 
     q2_grid = _discretize_crown_profile_quadrant(
-        tree, x_pts_q2, y_pts_q2, z_pts, hr, vr, full_intersection, vr_subgrid
+        tree, x_pts_q2, y_pts_q2, z_pts, hr, vr, full_intersection, n_vertical_subgrid
     )
 
     # Build the other quadrants by flipping the q2 grid about the x and y axes
@@ -64,15 +69,15 @@ def _discretize_crown_profile_quadrant(
     hr,
     vr,
     full_intersection=False,
-    vr_subgrid=0.1,
+    n_vertical_subgrid=10,
 ):
     """
     Build a 3D grid of a quadrant of a tree crown represented as a rotational
     solid.
     """
-    # Create a subgrid of the z-axis to increase the resolution of the crown
-    num_subgrid_cells_per_z = int(vr / vr_subgrid)
-    z_pts_subgrid = _resample_coords_grid_to_subgrid(z_pts, vr, vr_subgrid)
+    # Split each z-cell into n_vertical_subgrid sub-heights to resolve the crown
+    vr_subgrid = vr / n_vertical_subgrid
+    z_pts_subgrid = _resample_coords_grid_to_subgrid(z_pts, vr, n_vertical_subgrid)
     r_at_height_z = tree.get_crown_radius_at_height(z_pts_subgrid)
 
     # Compute the area of intersection between the tree crown and each cell
@@ -83,7 +88,7 @@ def _discretize_crown_profile_quadrant(
     # Convert the area of intersection to a volume fraction by summing the area
     # along the z-axis and dividing by the cell volume
     volume_subgrid = area * vr_subgrid
-    volume = _sum_area_along_axis(volume_subgrid, 0, num_subgrid_cells_per_z)
+    volume = _sum_area_along_axis(volume_subgrid, 0, n_vertical_subgrid)
     volume_fraction = np.minimum(volume / (hr * hr * vr), 1.0)
 
     return volume_fraction

--- a/fastfuels_core/voxelization/mass_distribution.py
+++ b/fastfuels_core/voxelization/mass_distribution.py
@@ -103,7 +103,13 @@ def _linear_height_quadratic_radial(r: ndarray, z: ndarray, tree: "Tree") -> nda
     ht = tree.height
     hd = tree.crown_profile_model.get_max_radius_height()
     d = 2.0 * tree.max_crown_radius
-    return ((z - hb) + 4.0 * (ht - hd) * r**2 / d**2) / (ht - hb)
+    weight = ((z - hb) + 4.0 * (ht - hd) * r**2 / d**2) / (ht - hb)
+    # Clamp to non-negative. When ``z_origin`` anchors the grid, the first cell
+    # center can land just below the crown base (``z < hb``); the linear term is
+    # then negative and, near the stem where the radial term is small, drives the
+    # weight below zero -- which would give that base voxel a negative bulk
+    # density. The weight is a density and must be non-negative by construction.
+    return np.maximum(weight, 0.0)
 
 
 class LinearHeightQuadraticRadialDensity(GradientDensity):

--- a/fastfuels_core/voxelization/mass_distribution.py
+++ b/fastfuels_core/voxelization/mass_distribution.py
@@ -1,0 +1,134 @@
+"""Mass-distribution models: spread a tree's crown mass across occupied voxels.
+
+This is the step *after* voxelization. The occupancy step (marching squares or
+subgrid sampling) produces a volume-fraction grid; a ``DensityField`` then turns
+that occupancy into a bulk-density grid (kg/m^3) by deciding *how much* of the
+crown mass sits in each voxel.
+
+Two flavors ship here:
+
+* :class:`UniformDensity` -- one constant bulk density through the crown
+  (mass / occupied volume). This is the original behavior.
+* :class:`GradientDensity` -- distribute mass with an arbitrary weight function
+  ``w(r, z, tree)``; the result is renormalized to conserve the crown mass, so a
+  constant weight recovers :class:`UniformDensity`. Named subclasses (e.g.
+  :class:`LinearHeightQuadraticRadialDensity`) pin a specific weight.
+
+The occupancy step and the mass-distribution step are deliberately independent:
+any occupancy backend composes with any ``DensityField``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Callable
+
+import numpy as np
+from numpy import ndarray
+
+if TYPE_CHECKING:
+    from fastfuels_core.trees import Tree
+
+# A weight function maps per-voxel radial distance ``r`` and height ``z`` (plus
+# the tree, for geometry) to non-negative relative weights over the voxel grid.
+WeightFunction = Callable[[ndarray, ndarray, "Tree"], ndarray]
+
+
+class DensityField(ABC):
+    """Turns an occupancy grid into a bulk-density grid (kg/m^3).
+
+    Implementations receive the ``occupancy`` grid (volume fraction per voxel),
+    the ``tree``, per-voxel radial distance ``r`` and height ``z`` (broadcastable
+    to the grid), and the ``cell_volume`` (m^3), and return a bulk-density grid
+    of the same shape as ``occupancy``.
+    """
+
+    @abstractmethod
+    def apply(
+        self,
+        occupancy: ndarray,
+        tree: "Tree",
+        r: ndarray,
+        z: ndarray,
+        cell_volume: float,
+    ) -> ndarray:
+        raise NotImplementedError
+
+
+class UniformDensity(DensityField):
+    """Constant bulk density through the crown: ``mass / occupied volume``.
+
+    Equivalent to the original ``VoxelizedTree.distribute_biomass``: the whole
+    crown mass is spread at a single bulk density over the occupied volume.
+    """
+
+    def apply(self, occupancy, tree, r, z, cell_volume):
+        volume = float(occupancy.sum()) * cell_volume
+        if volume <= 0.0:
+            return np.zeros_like(occupancy, dtype=float)
+        return occupancy * (tree.foliage_biomass / volume)
+
+
+class GradientDensity(DensityField):
+    """Distribute crown mass with an arbitrary weight function ``w(r, z, tree)``.
+
+    The weight sets the *shape* of the distribution; the result is renormalized
+    so the integrated mass equals the tree's crown mass. Because of that
+    renormalization a constant weight reproduces :class:`UniformDensity` exactly.
+
+    Parameters
+    ----------
+    weight_fn : callable
+        ``weight_fn(r, z, tree) -> ndarray`` returning non-negative relative
+        weights broadcast over the voxel grid. ``r`` is the radial distance from
+        the stem and ``z`` the height; both are broadcastable to the occupancy
+        grid. Any new gradient is just a new weight function.
+    """
+
+    def __init__(self, weight_fn: WeightFunction):
+        self.weight_fn = weight_fn
+
+    def apply(self, occupancy, tree, r, z, cell_volume):
+        weight = np.asarray(self.weight_fn(r, z, tree), dtype=float)
+        raw = weight * occupancy
+        total = float(raw.sum()) * cell_volume
+        if total <= 0.0:
+            return np.zeros_like(occupancy, dtype=float)
+        return raw * (tree.foliage_biomass / total)
+
+
+def _linear_height_quadratic_radial(r: ndarray, z: ndarray, tree: "Tree") -> ndarray:
+    """Weight that is linear in height and quadratic in radius (see class below)."""
+    hb = tree.crown_base_height
+    ht = tree.height
+    hd = tree.crown_profile_model.get_max_radius_height()
+    d = 2.0 * tree.max_crown_radius
+    return ((z - hb) + 4.0 * (ht - hd) * r**2 / d**2) / (ht - hb)
+
+
+class LinearHeightQuadraticRadialDensity(GradientDensity):
+    """Crown density that rises linearly with height and quadratically with radius.
+
+    .. math::
+
+        w(r, z) = \\frac{(z - H_b) + 4 (H_t - H_d)\\, r^2 / D^2}{H_t - H_b}
+
+    where :math:`H_b` is the crown base, :math:`H_t` the tree top, :math:`H_d`
+    the height of maximum crown diameter (taken from the crown profile's peak,
+    ``crown_profile_model.get_max_radius_height()``), and :math:`D = 2\\cdot`
+    ``max_crown_radius``. The weight is zero at the crown-base center and peaks
+    at the top outer rim.
+
+    This reproduces the vertical + radial fuel gradient of **LANL Trees**
+    (``treesMACA``, ``fuels_create.F90``). Pair it with a crown envelope that
+    peaks at :math:`H_d` -- i.e. ``crown_profile_model_type="paraboloid"`` -- to
+    match LANL's crown shape as well as its mass gradient.
+
+    Note that :class:`GradientDensity` renormalizes to conserve the tree's crown
+    mass, so this yields LANL's *shape* with mass conserved; LANL's own absolute
+    bulk density is ~0.75x that (its canopy bulk density is defined over an
+    ellipsoid crown volume rather than the paraboloid it fills).
+    """
+
+    def __init__(self):
+        super().__init__(_linear_height_quadratic_radial)

--- a/fastfuels_core/voxelization/subgrid.py
+++ b/fastfuels_core/voxelization/subgrid.py
@@ -1,0 +1,101 @@
+"""Subgrid voxelization.
+
+A different method for building the crown volume-fraction grid than
+:mod:`marching_squares`: instead of computing the exact circle-cell intersection
+area, each output voxel is split into ``n_subgrid`` subcells per axis and the
+volume fraction is the fraction of subcell centers that fall inside the crown
+envelope. This is LANL Trees' own rule (``n_subgrid=10`` reproduces its
+10x10x10 sampling).
+
+Compared to marching squares:
+
+* marching squares is exact in the horizontal and only subdivides the vertical;
+  subgrid subdivides all three axes, so it is approximate (converging as
+  ``n_subgrid`` grows) but needs no rotational-solid area math.
+* the "inside" test is a single predicate (``r <= R(z)``), so this method
+  extends to any geometry for which that predicate can be written -- the natural
+  home for non-rotational crowns a circle-area kernel can't express.
+
+Both methods expose ``discretize_crown_profile`` with the same output -- a
+``(nz, ny, nx)`` volume-fraction grid on the same axes -- so they are
+interchangeable inputs to
+``VoxelizedTree(tree, grid, hr, vr).distribute_biomass(density_field=...)``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy import ndarray
+
+from fastfuels_core.voxelization._coords import (
+    CenteringMode,
+    _get_horizontal_tree_coords,
+    _get_vertical_tree_coords,
+    _resample_coords_grid_to_subgrid,
+)
+
+if TYPE_CHECKING:
+    from fastfuels_core.trees import Tree
+
+
+def discretize_crown_profile(
+    tree: "Tree",
+    hr: float,
+    vr: float,
+    centering: CenteringMode = "cell",
+    n_subgrid: int = 10,
+    z_origin: float = None,
+) -> ndarray:
+    """Voxelize a crown to a volume-fraction grid by subgrid sampling.
+
+    Sibling to :func:`marching_squares.discretize_crown_profile` -- same output,
+    different method. Each output voxel is divided into ``n_subgrid`` subcells
+    along each axis (``n_subgrid**3`` total); the volume fraction is the fraction
+    of those subcell centers inside the crown envelope ``r <= R(z)``.
+
+    Parameters
+    ----------
+    tree : Tree
+    hr, vr : float
+        Horizontal and vertical output resolution (m).
+    centering : {"cell", "vertex"}
+        Grid centering, matching the marching-squares backend.
+    n_subgrid : int
+        Subcells per axis per voxel (>= 1). ``n_subgrid=10`` matches LANL Trees;
+        ``n_subgrid=1`` samples each voxel once, at its center.
+    z_origin : float, optional
+        Reference height the z-cells align to (see
+        ``_get_vertical_tree_coords``). ``None`` keeps the crown-base-centered
+        grid; a float aligns cell boundaries to ``z_origin + k*vr`` (e.g. the
+        ground elevation) for registration to a shared domain grid.
+
+    Returns
+    -------
+    ndarray, shape (nz, ny, nx)
+        Volume fraction in [0, 1] on the same axes as the marching-squares
+        backend.
+    """
+    if n_subgrid < 1:
+        raise ValueError(f"n_subgrid must be a positive integer, got {n_subgrid}")
+    n_subgrid = int(n_subgrid)
+
+    xy_pts = _get_horizontal_tree_coords(hr, tree.max_crown_radius, centering=centering)
+    z_pts = _get_vertical_tree_coords(vr, tree.height, tree.crown_base_height, z_origin)
+    nz, nxy = len(z_pts), len(xy_pts)
+
+    # Subcell centers along each axis (exact: len * n_subgrid points).
+    xy_sub = _resample_coords_grid_to_subgrid(xy_pts, hr, n_subgrid)
+    z_sub = _resample_coords_grid_to_subgrid(z_pts, vr, n_subgrid)
+
+    # Inside-crown test per subcell: r <= R(z). get_crown_radius_at_height
+    # returns 0 outside [crown_base, height], so those subcells fall outside.
+    r_squared = xy_sub[None, :] ** 2 + xy_sub[:, None] ** 2  # (ny_sub, nx_sub)
+    radius = np.asarray(tree.get_crown_radius_at_height(z_sub))  # (nz_sub,)
+    inside = r_squared[None, :, :] <= (radius**2)[:, None, None]
+
+    # Average the subcells of each voxel -> volume fraction.
+    return inside.reshape(nz, n_subgrid, nxy, n_subgrid, nxy, n_subgrid).mean(
+        axis=(1, 3, 5)
+    )

--- a/fastfuels_core/voxelization/tree.py
+++ b/fastfuels_core/voxelization/tree.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 # Internal imports
-from fastfuels_core.voxelization._coords import CenteringMode
+from fastfuels_core.voxelization._coords import (
+    CenteringMode,
+    _get_horizontal_tree_coords,
+    _get_vertical_tree_coords,
+)
 from fastfuels_core.voxelization.marching_squares import discretize_crown_profile
+from fastfuels_core.voxelization.mass_distribution import DensityField, UniformDensity
 from fastfuels_core.voxelization.sampling import sample_occupied_cells
 
 if TYPE_CHECKING:
@@ -17,19 +22,48 @@ from numpy import ndarray
 
 class VoxelizedTree:
     def __init__(
-        self, tree: "Tree", grid: ndarray, hr, vr, centering: CenteringMode = "cell"
+        self,
+        tree: "Tree",
+        grid: ndarray,
+        hr,
+        vr,
+        centering: CenteringMode = "cell",
+        z_origin: float = None,
     ):
         self.tree = tree
         self.grid = grid
         self.hr = hr
         self.vr = vr
         self.centering = centering
+        # Must match the z_origin the occupancy grid was built with so the
+        # density field's per-voxel heights line up with the grid.
+        self.z_origin = z_origin
 
-    def distribute_biomass(self):
-        volume = np.sum(self.grid) * self.hr * self.hr * self.vr
-        foliage_mpv = self.tree.foliage_biomass / volume
-        biomass_grid = self.grid.copy() * foliage_mpv
-        return biomass_grid
+    def distribute_biomass(self, density_field: DensityField = None) -> ndarray:
+        """Distribute the tree's crown mass across occupied voxels.
+
+        The mass-distribution step is independent of how the occupancy grid was
+        produced. ``density_field`` selects the distribution; it defaults to
+        :class:`UniformDensity`, reproducing the original constant-density
+        behavior.
+        """
+        if density_field is None:
+            density_field = UniformDensity()
+        z, r = self._voxel_coordinates()
+        cell_volume = self.hr * self.hr * self.vr
+        return density_field.apply(self.grid, self.tree, r, z, cell_volume)
+
+    def _voxel_coordinates(self) -> tuple[ndarray, ndarray]:
+        """Per-voxel height ``z`` (nz,1,1) and radial distance from the stem
+        ``r`` (1,ny,nx), matching ``self.grid``'s axes."""
+        z = _get_vertical_tree_coords(
+            self.vr, self.tree.height, self.tree.crown_base_height, self.z_origin
+        )
+        xy = _get_horizontal_tree_coords(
+            self.hr, self.tree.max_crown_radius, centering=self.centering
+        )
+        r = np.sqrt(xy[None, :] ** 2 + xy[:, None] ** 2)
+        return z[:, None, None], r[None, :, :]
 
 
 def voxelize_tree(
@@ -40,13 +74,15 @@ def voxelize_tree(
     **kwargs,
 ) -> VoxelizedTree:
 
-    vr_subgrid = kwargs.get("vr_subgrid", 0.1)
+    n_vertical_subgrid = kwargs.get("n_vertical_subgrid", 10)
+    z_origin = kwargs.get("z_origin", None)
     crown_profile_mask = discretize_crown_profile(
         tree,
         horizontal_resolution,
         vertical_resolution,
         centering=centering,
-        vr_subgrid=vr_subgrid,
+        n_vertical_subgrid=n_vertical_subgrid,
+        z_origin=z_origin,
     )
 
     alpha = kwargs.get("alpha", 0.5)
@@ -58,5 +94,10 @@ def voxelize_tree(
         crown_profile_mask, alpha, beta, rho, seed
     )
     return VoxelizedTree(
-        tree, sampled_crown_mask, horizontal_resolution, vertical_resolution, centering
+        tree,
+        sampled_crown_mask,
+        horizontal_resolution,
+        vertical_resolution,
+        centering,
+        z_origin=z_origin,
     )

--- a/tests/test_mass_distribution.py
+++ b/tests/test_mass_distribution.py
@@ -1,0 +1,174 @@
+# Internal imports
+from fastfuels_core.trees import Tree
+from fastfuels_core.crown_profile_models.beta import BetaCrownProfile
+from fastfuels_core.voxelization import (
+    voxelize_tree,
+    DensityField,
+    UniformDensity,
+    GradientDensity,
+    LinearHeightQuadraticRadialDensity,
+)
+from fastfuels_core.voxelization.mass_distribution import (
+    _linear_height_quadratic_radial,
+)
+
+# External imports
+import pytest
+import numpy as np
+
+
+HR, VR = 2.0, 1.0
+
+
+def _paraboloid_tree(height=31.5, cbh=3.12, crown_dia=9.34, mass=375.08):
+    """A deterministic paraboloid tree (Hd at the beta mode), like tree_43050."""
+    crown_ratio = (height - cbh) / height
+    hd = float(
+        BetaCrownProfile(
+            species_code=122, crown_base_height=cbh, crown_length=height - cbh
+        ).get_max_radius_height()
+    )
+    return Tree(
+        species_code=122,
+        status_code=1,
+        diameter=72.6,
+        height=height,
+        crown_ratio=crown_ratio,
+        crown_profile_model_type="paraboloid",
+        max_crown_radius=crown_dia / 2.0,
+        max_crown_diameter_height=hd,
+        crown_fuel_load=mass,
+    )
+
+
+def _full_occupancy(tree):
+    """Deterministic, fully-occupied crown (no stochastic thinning)."""
+    return voxelize_tree(tree, HR, VR, alpha=0.0, beta=0.0, rho=1.0, seed=1)
+
+
+def _mass(grid):
+    return float(grid.sum()) * HR * HR * VR
+
+
+# --------------------------------------------------------------------------- #
+# UniformDensity
+# --------------------------------------------------------------------------- #
+
+
+class TestUniformDensity:
+    def test_matches_legacy_formula_exactly(self):
+        tree = _paraboloid_tree()
+        vt = _full_occupancy(tree)
+        legacy = vt.grid * (tree.foliage_biomass / (vt.grid.sum() * HR * HR * VR))
+        assert np.array_equal(vt.distribute_biomass(UniformDensity()), legacy)
+
+    def test_is_the_default(self):
+        vt = _full_occupancy(_paraboloid_tree())
+        assert np.array_equal(
+            vt.distribute_biomass(), vt.distribute_biomass(UniformDensity())
+        )
+
+    def test_conserves_mass(self):
+        tree = _paraboloid_tree()
+        vt = _full_occupancy(tree)
+        assert _mass(vt.distribute_biomass(UniformDensity())) == pytest.approx(
+            tree.foliage_biomass
+        )
+
+    def test_bulk_density_proportional_to_occupancy(self):
+        # Defining property of uniform density: bulk density is one constant
+        # times the volume fraction, so bd / occupancy is the same everywhere.
+        vt = _full_occupancy(_paraboloid_tree())
+        bd = vt.distribute_biomass(UniformDensity())
+        occ = vt.grid
+        ratio = bd[occ > 0] / occ[occ > 0]
+        assert np.allclose(ratio, ratio[0])
+
+    def test_empty_grid_returns_zeros_not_nan(self):
+        tree = _paraboloid_tree()
+        vt = _full_occupancy(tree)
+        vt.grid = np.zeros_like(vt.grid)
+        out = vt.distribute_biomass(UniformDensity())
+        assert np.all(out == 0.0) and np.all(np.isfinite(out))
+
+
+# --------------------------------------------------------------------------- #
+# GradientDensity
+# --------------------------------------------------------------------------- #
+
+
+class TestGradientDensity:
+    def test_constant_weight_equals_uniform(self):
+        vt = _full_occupancy(_paraboloid_tree())
+        const = GradientDensity(lambda r, z, tree: np.ones_like(r * z))
+        assert np.allclose(
+            vt.distribute_biomass(const), vt.distribute_biomass(UniformDensity())
+        )
+
+    def test_conserves_mass_for_arbitrary_weight(self):
+        tree = _paraboloid_tree()
+        vt = _full_occupancy(tree)
+        # a lopsided weight that still must integrate to the crown mass
+        field = GradientDensity(lambda r, z, tree: z**2 + r + 1.0)
+        assert _mass(vt.distribute_biomass(field)) == pytest.approx(
+            tree.foliage_biomass
+        )
+
+    def test_empty_grid_returns_zeros_not_nan(self):
+        vt = _full_occupancy(_paraboloid_tree())
+        vt.grid = np.zeros_like(vt.grid)
+        out = vt.distribute_biomass(GradientDensity(lambda r, z, tree: r + z + 1))
+        assert np.all(out == 0.0) and np.all(np.isfinite(out))
+
+    def test_is_a_density_field(self):
+        assert isinstance(GradientDensity(lambda r, z, t: r), DensityField)
+
+
+# --------------------------------------------------------------------------- #
+# LinearHeightQuadraticRadialDensity (the LANL gradient)
+# --------------------------------------------------------------------------- #
+
+
+class TestLinearHeightQuadraticRadialDensity:
+    def test_conserves_mass(self):
+        tree = _paraboloid_tree()
+        vt = _full_occupancy(tree)
+        out = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
+        assert _mass(out) == pytest.approx(tree.foliage_biomass)
+
+    def test_is_top_weighted_relative_to_uniform(self):
+        vt = _full_occupancy(_paraboloid_tree())
+        z = vt._voxel_coordinates()[0].ravel()
+        uniform = vt.distribute_biomass(UniformDensity())
+        lanl = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
+
+        def com(g):
+            return (g.sum(axis=(1, 2)) * z).sum() / g.sum()
+
+        assert com(lanl) > com(uniform)
+
+    def test_is_outer_weighted_relative_to_uniform(self):
+        vt = _full_occupancy(_paraboloid_tree())
+        _, r = vt._voxel_coordinates()
+        r = np.broadcast_to(r, vt.grid.shape)
+        uniform = vt.distribute_biomass(UniformDensity())
+        lanl = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
+        # mass-weighted mean radius is larger for the quadratic-radial gradient
+        assert (lanl * r).sum() / lanl.sum() > (uniform * r).sum() / uniform.sum()
+
+    def test_weight_matches_analytic_formula(self):
+        tree = _paraboloid_tree()
+        hb, ht = tree.crown_base_height, tree.height
+        hd = tree.crown_profile_model.get_max_radius_height()
+        d = 2.0 * tree.max_crown_radius
+        r = np.array([0.0, 1.5, 3.0])
+        z = np.array([hb, (hb + ht) / 2, ht])
+        expected = ((z - hb) + 4.0 * (ht - hd) * r**2 / d**2) / (ht - hb)
+        assert np.allclose(_linear_height_quadratic_radial(r, z, tree), expected)
+
+    def test_weight_zero_at_crown_base_center(self):
+        tree = _paraboloid_tree()
+        w = _linear_height_quadratic_radial(
+            np.array(0.0), np.array(tree.crown_base_height), tree
+        )
+        assert w == pytest.approx(0.0)

--- a/tests/test_subgrid.py
+++ b/tests/test_subgrid.py
@@ -1,0 +1,111 @@
+# Core imports
+import math
+
+# Internal imports
+from tests.utils import make_random_tree
+from fastfuels_core.trees import Tree
+from fastfuels_core.crown_profile_models.beta import BetaCrownProfile
+from fastfuels_core.voxelization import (
+    VoxelizedTree,
+    LinearHeightQuadraticRadialDensity,
+)
+from fastfuels_core.voxelization import subgrid
+from fastfuels_core.voxelization.marching_squares import discretize_crown_profile
+
+# External imports
+import pytest
+import numpy as np
+
+
+HR, VR = 2.0, 1.0
+
+
+def _paraboloid_tree(height=31.5, cbh=3.12, crown_dia=9.34, mass=375.08):
+    hd = float(
+        BetaCrownProfile(
+            species_code=122, crown_base_height=cbh, crown_length=height - cbh
+        ).get_max_radius_height()
+    )
+    return Tree(
+        species_code=122,
+        status_code=1,
+        diameter=72.6,
+        height=height,
+        crown_ratio=(height - cbh) / height,
+        crown_profile_model_type="paraboloid",
+        max_crown_radius=crown_dia / 2.0,
+        max_crown_diameter_height=hd,
+        crown_fuel_load=mass,
+    )
+
+
+class TestSubgridDiscretizeCrownProfile:
+    def test_shape_matches_marching_squares(self):
+        tree = _paraboloid_tree()
+        sampled = subgrid.discretize_crown_profile(tree, HR, VR)
+        marching = discretize_crown_profile(tree, HR, VR)
+        assert sampled.shape == marching.shape
+
+    def test_volume_fraction_in_unit_range(self):
+        grid = subgrid.discretize_crown_profile(_paraboloid_tree(), HR, VR)
+        assert np.all(grid >= 0.0) and np.all(grid <= 1.0)
+
+    def test_symmetric_about_stem(self):
+        grid = subgrid.discretize_crown_profile(_paraboloid_tree(), HR, VR)
+        assert np.allclose(grid, np.flip(grid, axis=1))
+        assert np.allclose(grid, np.flip(grid, axis=2))
+
+    def test_n_subgrid_one_samples_cell_centers(self):
+        # n_subgrid=1 -> occupancy is 0/1 per voxel (single center sample)
+        grid = subgrid.discretize_crown_profile(_paraboloid_tree(), HR, VR, n_subgrid=1)
+        assert set(np.unique(grid)).issubset({0.0, 1.0})
+        assert grid.sum() > 0
+
+    def test_invalid_n_subgrid_raises(self):
+        with pytest.raises(ValueError, match="n_subgrid"):
+            subgrid.discretize_crown_profile(_paraboloid_tree(), HR, VR, n_subgrid=0)
+
+    def test_approximates_paraboloid_crown_volume(self):
+        # Analytic paraboloid crown volume = pi * D^2 * L / 8.
+        tree = _paraboloid_tree()
+        d = 2 * tree.max_crown_radius
+        length = tree.height - tree.crown_base_height
+        analytic = math.pi * d**2 * length / 8.0
+        volume = (
+            subgrid.discretize_crown_profile(tree, HR, VR, n_subgrid=10).sum()
+            * HR
+            * HR
+            * VR
+        )
+        assert volume == pytest.approx(analytic, rel=0.05)
+
+    def test_converges_to_marching_squares(self):
+        # Sampled occupancy should approach the exact marching-squares volume
+        # fraction as the subgrid is refined.
+        tree = _paraboloid_tree()
+        exact = discretize_crown_profile(tree, HR, VR).sum()
+        errors = [
+            abs(
+                subgrid.discretize_crown_profile(tree, HR, VR, n_subgrid=n).sum()
+                - exact
+            )
+            for n in (2, 6, 16)
+        ]
+        assert errors[0] > errors[1] > errors[2]
+
+    def test_composes_with_voxelized_tree_and_conserves_mass(self):
+        tree = _paraboloid_tree()
+        grid = subgrid.discretize_crown_profile(tree, HR, VR)
+        vt = VoxelizedTree(tree, grid, HR, VR)
+        for field in (None, LinearHeightQuadraticRadialDensity()):
+            bd = vt.distribute_biomass(field)
+            assert bd.sum() * HR * HR * VR == pytest.approx(tree.foliage_biomass)
+
+    def test_works_for_allometric_crowns(self):
+        # Not just geometric profiles: the r <= R(z) test works for any crown.
+        tree = make_random_tree(
+            species_code=122, height=20.0, crown_ratio=0.6, crown_profile_model="beta"
+        )
+        grid = subgrid.discretize_crown_profile(tree, HR, VR)
+        assert grid.shape == discretize_crown_profile(tree, HR, VR).shape
+        assert grid.sum() > 0

--- a/tests/test_voxelization.py
+++ b/tests/test_voxelization.py
@@ -355,56 +355,57 @@ class TestGetVerticalTreeCoords:
 
 class TestResampleCoordsGridToSubgrid:
     def test_resample(self):
+        # Third arg is now a subcell COUNT, not a spacing (count = spacing / spacing).
         original_pts = np.array([0.5])
         original_spacing = 1
-        new_spacing = 0.5
+        n_subgrid = 2  # was new_spacing=0.5
         expected_pts_1 = np.array([0.25, 0.75])
         resampled_pts_1 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
+            original_pts, original_spacing, n_subgrid
         )
         assert np.allclose(resampled_pts_1, expected_pts_1)
 
         original_pts = np.array([0.5])
         original_spacing = 1
-        new_spacing = 0.25
+        n_subgrid = 4  # was new_spacing=0.25
         expected_pts_2 = np.array([0.125, 0.375, 0.625, 0.875])
         resampled_pts_2 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
+            original_pts, original_spacing, n_subgrid
         )
         assert np.allclose(resampled_pts_2, expected_pts_2)
 
         original_pts = np.array([0.5])
         original_spacing = 1
-        new_spacing = 0.1
+        n_subgrid = 10  # was new_spacing=0.1
         expected_pts_3 = np.array(
             [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95]
         )
         resampled_pts_3 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
+            original_pts, original_spacing, n_subgrid
         )
         assert np.allclose(resampled_pts_3, expected_pts_3)
 
         original_pts = np.array([0.5, 1.5])
         original_spacing = 1
-        new_spacing = 0.5
+        n_subgrid = 2
         expected_pts_4 = np.array([0.25, 0.75, 1.25, 1.75])
         resampled_pts_4 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
+            original_pts, original_spacing, n_subgrid
         )
         assert np.allclose(resampled_pts_4, expected_pts_4)
 
         original_pts = np.array([0.5, 1.5, 2.5])
         original_spacing = 1
-        new_spacing = 0.5
+        n_subgrid = 2
         expected_pts_5 = np.array([0.25, 0.75, 1.25, 1.75, 2.25, 2.75])
         resampled_pts_5 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
+            original_pts, original_spacing, n_subgrid
         )
         assert np.allclose(resampled_pts_5, expected_pts_5)
 
         original_pts = np.array([0.5, 1.5, 2.5])
         original_spacing = 1
-        new_spacing = 0.25
+        n_subgrid = 4
         expected_pts_6 = np.array(
             [
                 0.125,
@@ -422,88 +423,22 @@ class TestResampleCoordsGridToSubgrid:
             ]
         )
         resampled_pts_6 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
+            original_pts, original_spacing, n_subgrid
         )
         assert np.allclose(resampled_pts_6, expected_pts_6)
 
-        original_pts = np.array([0.5, 1.5, 2.5])
-        original_spacing = 1
-        new_spacing = 0.1
-        expected_pts_7 = np.array(
-            [
-                0.05,
-                0.15,
-                0.25,
-                0.35,
-                0.45,
-                0.55,
-                0.65,
-                0.75,
-                0.85,
-                0.95,
-                1.05,
-                1.15,
-                1.25,
-                1.35,
-                1.45,
-                1.55,
-                1.65,
-                1.75,
-                1.85,
-                1.95,
-                2.05,
-                2.15,
-                2.25,
-                2.35,
-                2.45,
-                2.55,
-                2.65,
-                2.75,
-                2.85,
-                2.95,
-            ]
-        )
-        resampled_pts_7 = _resample_coords_grid_to_subgrid(
-            original_pts, original_spacing, new_spacing
-        )
-        assert np.allclose(resampled_pts_7, expected_pts_7)
+    def test_count_that_has_no_clean_spacing(self):
+        # 3 subcells of 1/3 m: impossible under the old divide-evenly spacing
+        # rule, exact under the count rule (always len(grid) * n points).
+        pts = _resample_coords_grid_to_subgrid(np.array([0.5, 1.5]), 1, 3)
+        assert pts.shape == (6,)
+        assert np.allclose(pts, [1 / 6, 3 / 6, 5 / 6, 1 + 1 / 6, 1 + 3 / 6, 1 + 5 / 6])
 
-    def test_same_resolution_shape(self):
-        # Test 1m resolution
+    def test_single_subcell_returns_cell_centers(self):
+        # n_subgrid == 1 -> one sample per cell, at its center (no subdivision)
         grid = np.arange(0.5, 100.5, 1)
-        grid_spacing = 1
-        new_spacing = 1
-        resampled_grid = _resample_coords_grid_to_subgrid(
-            grid, grid_spacing, new_spacing
-        )
-        assert resampled_grid.shape == grid.shape
-
-        # Test 0.5m resolution
-        grid = np.arange(0.25, 100.25, 0.5)
-        grid_spacing = 0.5
-        new_spacing = 0.5
-        resampled_grid = _resample_coords_grid_to_subgrid(
-            grid, grid_spacing, new_spacing
-        )
-        assert resampled_grid.shape == grid.shape
-
-        # Test 0.25m resolution
-        grid = np.arange(0.125, 100.125, 0.25)
-        grid_spacing = 0.25
-        new_spacing = 0.25
-        resampled_grid = _resample_coords_grid_to_subgrid(
-            grid, grid_spacing, new_spacing
-        )
-        assert resampled_grid.shape == grid.shape
-
-        # Test 0.1m resolution
-        grid = np.arange(0.05, 100.05, 0.1)
-        grid_spacing = 0.1
-        new_spacing = 0.1
-        resampled_grid = _resample_coords_grid_to_subgrid(
-            grid, grid_spacing, new_spacing
-        )
-        assert resampled_grid.shape == grid.shape
+        resampled = _resample_coords_grid_to_subgrid(grid, 1, 1)
+        assert np.array_equal(resampled, grid)
 
 
 class TestComputeCircleSegmentArea:
@@ -1329,59 +1264,45 @@ class TestDiscretizeCrownProfile:
         assert grid.shape[2] % 2 == 0
         assert np.sum(grid) > 0
 
-    def test_vr_subgrid_default_backward_compatible(self):
-        """Passing vr_subgrid=0.1 explicitly matches the default."""
+    def test_n_vertical_subgrid_default_is_ten(self):
+        """The default matches n_vertical_subgrid=10 (10 sub-heights per cell)."""
         test_tree = Tree(122, 1, 24, 20.66443, 0.5)
         grid_default = discretize_crown_profile(test_tree, 1, 1)
-        grid_explicit = discretize_crown_profile(test_tree, 1, 1, vr_subgrid=0.1)
+        grid_explicit = discretize_crown_profile(test_tree, 1, 1, n_vertical_subgrid=10)
         assert np.array_equal(grid_default, grid_explicit)
 
-    def test_vr_subgrid_different_values(self):
-        """Different valid vr_subgrid values produce reasonable results."""
+    def test_n_vertical_subgrid_different_values(self):
+        """Different subgrid counts produce reasonable volume-fraction grids."""
         test_tree = Tree(122, 1, 24, 20.66443, 0.5)
-        for vr_subgrid in [0.05, 0.1, 0.25, 0.5]:
-            grid = discretize_crown_profile(test_tree, 1, 1, vr_subgrid=vr_subgrid)
+        for n in [1, 2, 4, 10, 20]:
+            grid = discretize_crown_profile(test_tree, 1, 1, n_vertical_subgrid=n)
             assert np.all(grid >= 0)
             assert np.all(grid <= 1)
             assert np.sum(grid) > 0
 
-    def test_vr_subgrid_equals_vr(self):
-        """vr_subgrid equal to vr means no subdivision."""
+    def test_n_vertical_subgrid_one_means_no_subdivision(self):
+        """n_vertical_subgrid=1 evaluates each z-cell once, at its center."""
         test_tree = Tree(122, 1, 24, 20.66443, 0.5)
-        grid = discretize_crown_profile(test_tree, 1, 1, vr_subgrid=1.0)
+        grid = discretize_crown_profile(test_tree, 1, 1, n_vertical_subgrid=1)
         assert np.all(grid >= 0)
         assert np.all(grid <= 1)
         assert np.sum(grid) > 0
 
-    def test_vr_subgrid_invalid_raises(self):
-        """vr_subgrid that doesn't divide evenly into vr raises ValueError."""
+    def test_n_vertical_subgrid_count_with_no_clean_spacing(self):
+        """A count whose implied spacing is not a clean float (3 -> 1/3 m) is
+        fine now -- it was impossible under the old divide-evenly rule."""
         test_tree = Tree(122, 1, 24, 20.66443, 0.5)
-        with pytest.raises(ValueError, match="vr_subgrid"):
-            discretize_crown_profile(test_tree, 1, 1, vr_subgrid=0.3)
-        with pytest.raises(ValueError, match="vr_subgrid"):
-            discretize_crown_profile(test_tree, 1, 0.5, vr_subgrid=0.3)
-        with pytest.raises(ValueError, match="vr_subgrid"):
-            discretize_crown_profile(test_tree, 1, 1, vr_subgrid=0.7)
-        with pytest.raises(ValueError, match="vr_subgrid"):
-            discretize_crown_profile(test_tree, 1, 2, vr_subgrid=0.3)
+        for n in [3, 7, 9]:
+            grid = discretize_crown_profile(test_tree, 1, 1, n_vertical_subgrid=n)
+            assert np.sum(grid) > 0
 
-    def test_vr_subgrid_valid_does_not_raise(self):
-        """Valid vr_subgrid values should not raise, even with tricky floats."""
+    def test_n_vertical_subgrid_invalid_raises(self):
+        """Counts below 1 are invalid."""
         test_tree = Tree(122, 1, 24, 20.66443, 0.5)
-        # These all divide evenly but can have float representation issues
-        valid_pairs = [
-            (1.0, 0.1),
-            (1.0, 0.2),
-            (1.0, 0.5),
-            (0.5, 0.1),
-            (0.5, 0.25),
-            (2.0, 0.1),
-            (2.0, 0.2),
-            (2.0, 0.4),
-            (2.0, 1.0),
-        ]
-        for vr, vr_subgrid in valid_pairs:
-            discretize_crown_profile(test_tree, 1, vr, vr_subgrid=vr_subgrid)
+        with pytest.raises(ValueError, match="n_vertical_subgrid"):
+            discretize_crown_profile(test_tree, 1, 1, n_vertical_subgrid=0)
+        with pytest.raises(ValueError, match="n_vertical_subgrid"):
+            discretize_crown_profile(test_tree, 1, 1, n_vertical_subgrid=-2)
 
 
 class TestCenteringVisualization:

--- a/tests/test_z_origin.py
+++ b/tests/test_z_origin.py
@@ -1,0 +1,101 @@
+# Internal imports
+from fastfuels_core.trees import Tree
+from fastfuels_core.crown_profile_models.beta import BetaCrownProfile
+from fastfuels_core.voxelization import (
+    voxelize_tree,
+    VoxelizedTree,
+    LinearHeightQuadraticRadialDensity,
+)
+from fastfuels_core.voxelization import subgrid
+from fastfuels_core.voxelization.marching_squares import discretize_crown_profile
+from fastfuels_core.voxelization._coords import _get_vertical_tree_coords
+
+# External imports
+import numpy as np
+import pytest
+
+
+def _paraboloid_tree(height=31.5, cbh=3.12, crown_dia=9.34, mass=375.08):
+    hd = float(
+        BetaCrownProfile(
+            species_code=122, crown_base_height=cbh, crown_length=height - cbh
+        ).get_max_radius_height()
+    )
+    return Tree(
+        species_code=122,
+        status_code=1,
+        diameter=72.6,
+        height=height,
+        crown_ratio=(height - cbh) / height,
+        crown_profile_model_type="paraboloid",
+        max_crown_radius=crown_dia / 2.0,
+        max_crown_diameter_height=hd,
+        crown_fuel_load=mass,
+    )
+
+
+class TestVerticalCoords:
+    def test_none_is_crown_base_centered(self):
+        # default: crown base at the center of the first cell
+        z = _get_vertical_tree_coords(1.0, 10.0, 4.0, z_origin=None)
+        assert z[0] == pytest.approx(4.0)  # first cell centered on the crown base
+        assert np.allclose(np.diff(z), 1.0)
+
+    def test_float_aligns_boundaries_to_reference(self):
+        # z_origin=0: cell boundaries on integers, centers on half-integers
+        z = _get_vertical_tree_coords(1.0, 10.4, 4.2, z_origin=0.0)
+        assert np.allclose(z, [4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5])
+
+    def test_crown_base_falls_inside_first_cell_not_centered(self):
+        z = _get_vertical_tree_coords(1.0, 10.4, 4.2, z_origin=0.0)
+        cbh = 4.2
+        assert z[0] - 0.5 <= cbh <= z[0] + 0.5  # inside first cell
+        assert z[0] != pytest.approx(cbh)  # but not at its center
+
+    def test_phase_is_shared_across_trees(self):
+        # any z_origin=0 grid has centers at half-integers, regardless of cbh
+        for cbh in (3.1, 4.0, 5.73, 8.19):
+            z = _get_vertical_tree_coords(1.0, cbh + 5.0, cbh, z_origin=0.0)
+            assert np.allclose(z % 1.0, 0.5)
+
+
+class TestBackendsAcceptZOrigin:
+    def test_marching_squares_grid_matches_coords(self):
+        tree = _paraboloid_tree()
+        grid = discretize_crown_profile(tree, 2.0, 1.0, z_origin=0.0)
+        z = _get_vertical_tree_coords(1.0, tree.height, tree.crown_base_height, 0.0)
+        assert grid.shape[0] == len(z)
+
+    def test_subgrid_grid_matches_coords(self):
+        tree = _paraboloid_tree()
+        grid = subgrid.discretize_crown_profile(tree, 2.0, 1.0, z_origin=0.0)
+        z = _get_vertical_tree_coords(1.0, tree.height, tree.crown_base_height, 0.0)
+        assert grid.shape[0] == len(z)
+
+    def test_default_none_unchanged(self):
+        tree = _paraboloid_tree()
+        assert np.array_equal(
+            discretize_crown_profile(tree, 2.0, 1.0),
+            discretize_crown_profile(tree, 2.0, 1.0, z_origin=None),
+        )
+
+
+class TestVoxelizeTreeThreadsZOrigin:
+    def test_voxelize_tree_stores_and_uses_z_origin(self):
+        tree = _paraboloid_tree()
+        vt = voxelize_tree(tree, 2.0, 1.0, alpha=0.0, beta=0.0, rho=1.0, z_origin=0.0)
+        assert vt.z_origin == 0.0
+        z, _ = vt._voxel_coordinates()
+        # density-field heights align to the same half-integer grid
+        assert np.allclose(z.ravel() % 1.0, 0.5)
+
+    def test_mass_conserved_with_z_origin(self):
+        tree = _paraboloid_tree()
+        vt = voxelize_tree(tree, 2.0, 1.0, alpha=0.0, beta=0.0, rho=1.0, z_origin=0.0)
+        bulk = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
+        assert bulk.sum() * 2.0 * 2.0 * 1.0 == pytest.approx(tree.foliage_biomass)
+
+    def test_voxelized_tree_default_z_origin_is_none(self):
+        tree = _paraboloid_tree()
+        vt = VoxelizedTree(tree, np.zeros((3, 3, 3)), 2.0, 1.0)
+        assert vt.z_origin is None

--- a/tests/test_z_origin.py
+++ b/tests/test_z_origin.py
@@ -99,3 +99,16 @@ class TestVoxelizeTreeThreadsZOrigin:
         tree = _paraboloid_tree()
         vt = VoxelizedTree(tree, np.zeros((3, 3, 3)), 2.0, 1.0)
         assert vt.z_origin is None
+
+    def test_gradient_density_never_negative_when_first_cell_below_crown_base(self):
+        # A z_origin whose first cell center lands below the crown base (here
+        # cbh=3.9 -> first center 3.5 on a z_origin=0, vr=1 grid) makes the LANL
+        # linear-in-height weight negative near the stem. Bulk density is a
+        # density and must stay non-negative; mass is still conserved.
+        tree = _paraboloid_tree(cbh=3.9)
+        vt = voxelize_tree(tree, 2.0, 1.0, alpha=0.0, beta=0.0, rho=1.0, z_origin=0.0)
+        z, _ = vt._voxel_coordinates()
+        assert z.ravel()[0] < tree.crown_base_height  # precondition for the bug
+        bulk = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
+        assert np.all(bulk >= 0.0)
+        assert bulk.sum() * 2.0 * 2.0 * 1.0 == pytest.approx(tree.foliage_biomass)


### PR DESCRIPTION
Closes #82.

Separates crown voxelization into two independent, composable steps — an **occupancy method** (how a crown becomes a volume-fraction grid) and a **mass distribution** (how crown mass fills those voxels) — so reproducing LANL Trees (`treesMACA`) is one configuration of the pipeline rather than a bespoke path.

```
crown profile → occupancy (volume fraction) → mass distribution (bulk density)
  (shape)       marching squares | subgrid      uniform | gradient
```

## Changes

- **`mass_distribution.py`** — a `DensityField` step, kept separate from occupancy:
  - `UniformDensity` — reproduces the old `distribute_biomass` byte-for-byte.
  - `GradientDensity(weight_fn)` — distributes mass by an arbitrary weight, renormalized to conserve mass (so a constant weight equals uniform).
  - `LinearHeightQuadraticRadialDensity` — the LANL vertical+radial gradient `[(z-Hb) + 4(Ht-Hd)r^2/D^2]/(Ht-Hb)`, as a named subclass.
  - Applied via `VoxelizedTree.distribute_biomass(density_field=...)`.
- **`subgrid.py`** — a second `discretize_crown_profile` beside marching squares, estimating occupancy by binary point-in-crown subgrid sampling (LANL's 10^3 rule; also handles non-rotational geometry). Both backends share the same signature/output and are interchangeable.
- **`n_vertical_subgrid`** — replaces the resolution-based `vr_subgrid` with a subcell *count* (vertical only; marching squares stays exact horizontally). Count-based subgridding is exact by construction, so the old divide-evenly restriction is gone.
- **`z_origin`** — registers a crown to a shared domain grid (cell boundaries at `z_origin + k*vr`) instead of anchoring to each tree's crown base. Needed for exact LANL parity and consistent multi-tree registration.
- Re-exports `sample_occupied_cells` at the package level.

## Reproducing LANL

`paraboloid` profile + `subgrid` occupancy + `LinearHeightQuadraticRadialDensity`. Validated against real `treesMACA` output on the Sycan Unit 2A trees: on a shared grid (`z_origin` = ground) occupancy is an exact match (IoU = 1.000), with mass and the vertical/radial gradient reproduced.

## Compatibility

- Every new argument defaults to today's behavior; `UniformDensity` is byte-identical to the previous `distribute_biomass`.
- Marching squares stays the default occupancy method — subgrid sits beside it.
- +33 tests; full suite (25486) passes.
- The API consumer (`treevox`) pins a version, so it is unaffected until it deliberately bumps.
