### PR TITLE
Use Efraimidis-Spirakis sampling for crown voxel occupancy

### DIFF
--- a/fastfuels_core/voxelization/sampling.py
+++ b/fastfuels_core/voxelization/sampling.py
@@ -116,9 +116,16 @@ def _sample_voxels_from_probability_grid(
     the joint probability of each voxel, such that voxels with higher joint
     probability are more likely to be sampled. Voxels are sampled without
     replacement.
+
+    Uses the Efraimidis-Spirakis / Gumbel-top-k method: each candidate voxel i
+    is given a key ``log(u_i) / w_i`` (u_i ~ U(0, 1), w_i the voxel's
+    probability), and the n voxels with the largest keys are kept. This draws
+    from the same distribution as sequential weighted sampling without
+    replacement -- i.e. ``np.random.choice(..., replace=False, p=...)`` -- but
+    in a single O(N) pass rather than numpy's rejection loop, whose cost grows
+    with n. See Efraimidis & Spirakis (2006), Inf. Process. Lett. 97(5).
     """
-    if seed:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
 
     # If joint probability is all zeros, return an empty array
     if np.all(joint_probability == 0):
@@ -132,12 +139,28 @@ def _sample_voxels_from_probability_grid(
     if np.any(np.isnan(jp_flat)):
         return joint_probability
 
-    # Choose n indices from the flattened joint probability
-    chosen_indices = np.random.choice(
-        np.arange(joint_probability.size), n, replace=False, p=jp_flat
-    )
+    # Only voxels with positive probability are candidates for selection.
+    # (numpy's weighted choice likewise cannot draw more than this many.)
+    candidates = np.flatnonzero(jp_flat)
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    if n > candidates.size:
+        raise ValueError(
+            f"Cannot sample more voxels than have positive probability "
+            f"({n} requested, {candidates.size} available)"
+        )
+
+    selected_flat = np.zeros(joint_probability.size)
+    if n == 0:
+        return selected_flat.reshape(joint_probability.shape)
+
+    # Efraimidis-Spirakis keys; the n largest keys are the sampled voxels.
+    # argpartition finds the top n in O(N) without a full sort.
+    weights = jp_flat[candidates]
+    keys = np.log(rng.random(candidates.size)) / weights
+    kth = candidates.size - n
+    chosen_indices = candidates[np.argpartition(keys, kth)[kth:]]
 
     # Build flat selection array and reshape to original shape
-    selected_flat = np.zeros(joint_probability.size)
     selected_flat[chosen_indices] = jp_flat[chosen_indices]
     return selected_flat.reshape(joint_probability.shape)


### PR DESCRIPTION
## Summary

Replaces the weighted-without-replacement voxel occupancy sampler in `_sample_voxels_from_probability_grid` (the crown occupancy step, Marcozzi et al. 2025 §2.5.3) from legacy `np.random.choice(..., replace=False, p=)` to the **Efraimidis–Spirakis / Gumbel-top-k** method.

numpy implements weighted sampling without replacement as a rejection loop that recomputes `cumsum(p)` (O(N)) every iteration, with the iteration count growing as the sampling fraction `n/N` grows. This algorithm draws `n ≈ 0.5 × nonzero` — a large fraction — which is numpy's worst case, and it runs once per tree on the voxelization hot path. The modern `Generator.choice` shares the same rejection loop, so the win is the algorithm, not the API.

## Change

- Assign each candidate voxel a key `log(u_i) / w_i` and keep the `n` largest via `np.argpartition` — a single **O(N)** pass, independent of `n`, drawing from the same distribution as sequential weighted sampling without replacement.
- Use a local `np.random.default_rng(seed)` instead of mutating numpy's global RNG via `np.random.seed`; also honors `seed=0` (previously silently ignored by `if seed:`).
- Explicit `ValueError` guards for `n < 0` and `n >` number of positive-probability voxels.

## Correctness

- **Statistically identical** to the legacy sampler: matches the exact enumerated without-replacement distribution over output subsets (χ² goodness-of-fit p ≈ 0.41 over 400k trials); all pairwise joint-inclusion probabilities match to ~1e-3; two-sample test vs `Generator.choice` p ≈ 0.82.
- The existing `TestSampleCrownVoxels` contract passes unchanged (count, all-zero, `ValueError` cases, `n=0`, probability preference, seed reproducibility). Full test suite green.

## Benchmarks (real ponderosa crown grids, numpy 2.3.5)

| resolution | N (grid) | legacy | Gumbel/ES | speedup |
|---|---:|---:|---:|---:|
| 1.0 m | 1,458 | 58 µs | 12 µs | 4.9× |
| 0.5 m | 7,650 | 305 µs | 63 µs | 4.9× |
| 0.25 m | 48,114 | 2,490 µs | 419 µs | 5.9× |
| 0.15 m | 201,541 | 12,961 µs | 1,798 µs | 7.2× |

Cost is now flat in the sampling fraction (legacy grew linearly with it: 477 µs → 5,154 µs from ρ=0.05→0.90 at 0.25 m; Gumbel/ES stays ~400 µs).

## Note

The RNG stream changed (local `default_rng` vs the legacy global RNG), so same-seed output differs from the old code. The suite only asserts same-seed *equality* (which still holds), so no expected values needed updating; any downstream test pinning specific sampled indices to a fixed seed would need refreshing.

Closes #84.
