### PR TITLE
Expose deterministic/stochastic seam in occupancy sampling

### DIFF
--- a/fastfuels_core/voxelization/__init__.py
+++ b/fastfuels_core/voxelization/__init__.py
@@ -14,7 +14,11 @@ from fastfuels_core.voxelization.mass_distribution import (
     LinearHeightQuadraticRadialDensity,
     UniformDensity,
 )
-from fastfuels_core.voxelization.sampling import sample_occupied_cells
+from fastfuels_core.voxelization.sampling import (
+    compute_crown_probability_field,
+    sample_occupancy,
+    sample_occupied_cells,
+)
 from fastfuels_core.voxelization.tree import VoxelizedTree, voxelize_tree
 
 __all__ = [
@@ -22,6 +26,8 @@ __all__ = [
     "voxelize_tree",
     "CenteringMode",
     "discretize_crown_profile",
+    "compute_crown_probability_field",
+    "sample_occupancy",
     "sample_occupied_cells",
     "DensityField",
     "UniformDensity",

--- a/fastfuels_core/voxelization/sampling.py
+++ b/fastfuels_core/voxelization/sampling.py
@@ -7,6 +7,53 @@ from numpy import ndarray
 from scipy.ndimage import distance_transform_edt
 
 
+def compute_crown_probability_field(
+    volume_fraction_array: ndarray,
+    alpha: float,
+    beta: float,
+    rho: float = None,
+) -> tuple[ndarray, int]:
+    """Precompute the deterministic inputs to occupancy sampling.
+
+    Returns the joint crown-occupancy probability grid and the number of voxels
+    ``n`` to draw from it. Both depend only on
+    ``(volume_fraction_array, alpha, beta, rho)`` -- not on any random seed -- so
+    a caller drawing multiple occupancy realizations of the same crown can
+    compute this once and pass it to :func:`sample_occupancy` repeatedly,
+    avoiding a redundant (and EDT-heavy) field recompute per realization.
+    """
+    # Create a probability mask for the crown grid
+    mask_bool = np.where(volume_fraction_array > 0.0, 1.0, 0.0)
+    field = _compute_joint_probability(mask_bool, alpha, beta)
+
+    # Number of voxels to occupy from the crown density
+    if rho is None:
+        rho = _estimate_crown_density(np.sum(mask_bool))
+    n = int(np.count_nonzero(mask_bool) * rho)
+
+    return field, n
+
+
+def sample_occupancy(
+    volume_fraction_array: ndarray,
+    field: ndarray,
+    n: int,
+    seed: int = None,
+) -> ndarray:
+    """Draw one stochastic occupancy realization from a precomputed field.
+
+    ``field`` and ``n`` come from :func:`compute_crown_probability_field`. Only
+    this step consumes ``seed``: different seeds yield different occupancy
+    realizations drawn from the same shared field.
+    """
+    sampled = _sample_voxels_from_probability_grid(n, field, seed)
+
+    # Make non-zero selected voxels 1
+    selected = np.where(sampled > 0, 1.0, 0.0)
+
+    return selected * volume_fraction_array
+
+
 def sample_occupied_cells(
     volume_fraction_array: ndarray,
     alpha: float,
@@ -14,20 +61,15 @@ def sample_occupied_cells(
     rho: float = None,
     seed: int = None,
 ) -> ndarray:
-    # Create a probability mask for the crown grid
-    mask_bool = np.where(volume_fraction_array > 0.0, 1.0, 0.0)
-    mask_prob = _compute_joint_probability(mask_bool, alpha, beta)
+    """One-shot occupancy sampling: build the crown probability field and draw
+    a single realization from it.
 
-    # Choose n voxels from the joint probability grid
-    if rho is None:
-        rho = _estimate_crown_density(np.sum(mask_bool))
-    n = int(np.count_nonzero(mask_bool) * rho)
-    sampled = _sample_voxels_from_probability_grid(n, mask_prob, seed)
-
-    # Make non-zero selected voxels 1
-    selected = np.where(sampled > 0, 1.0, 0.0)
-
-    return selected * volume_fraction_array
+    Equivalent to ``sample_occupancy(vfa, *compute_crown_probability_field(vfa,
+    alpha, beta, rho), seed)``; kept as the convenience path for callers that
+    only need one realization.
+    """
+    field, n = compute_crown_probability_field(volume_fraction_array, alpha, beta, rho)
+    return sample_occupancy(volume_fraction_array, field, n, seed)
 
 
 def _compute_joint_probability(mask: ndarray, alpha: float, beta: float) -> ndarray:

--- a/tests/test_voxelization.py
+++ b/tests/test_voxelization.py
@@ -32,6 +32,9 @@ from fastfuels_core.voxelization.sampling import (
     _compute_vertical_probability,
     _compute_joint_probability,
     _sample_voxels_from_probability_grid,
+    compute_crown_probability_field,
+    sample_occupancy,
+    sample_occupied_cells,
 )
 
 # External imports
@@ -1998,6 +2001,64 @@ class TestSampleCrownVoxels:
         result2 = _sample_voxels_from_probability_grid(n, joint_probability, 43)
 
         assert not np.array_equal(result1, result2)
+
+
+class TestOccupancySeam:
+    """The public deterministic/stochastic seam: compute_crown_probability_field
+    + sample_occupancy must compose to exactly sample_occupied_cells, and the
+    field must be reusable across seeds (build once, draw many)."""
+
+    @staticmethod
+    def _mask():
+        # A realistic non-uniform volume-fraction grid with some empty cells.
+        rng = np.random.default_rng(0)
+        m = rng.random((5, 6, 7))
+        m[m < 0.4] = 0.0
+        return m
+
+    def test_two_phase_equals_one_shot(self):
+        m = self._mask()
+        cases = [
+            (0.5, 0.5, None, 1),
+            (0.5, 0.5, 0.5, 7),
+            (1.0, 2.0, 0.3, 42),
+            (0.5, 0.5, 1.0, 3),
+        ]
+        for alpha, beta, rho, seed in cases:
+            field, n = compute_crown_probability_field(m, alpha, beta, rho)
+            two_phase = sample_occupancy(m, field, n, seed)
+            one_shot = sample_occupied_cells(m, alpha, beta, rho, seed)
+            assert np.array_equal(one_shot, two_phase)
+
+    def test_field_is_deterministic(self):
+        m = self._mask()
+        f1, n1 = compute_crown_probability_field(m, 0.5, 0.5)
+        f2, n2 = compute_crown_probability_field(m, 0.5, 0.5)
+        assert np.array_equal(f1, f2)
+        assert n1 == n2
+
+    def test_reused_field_matches_one_shot_per_seed(self):
+        # Build the field once, draw many: each draw equals the one-shot call
+        # with the same seed. This is the hoist that consumers rely on.
+        m = self._mask()
+        field, n = compute_crown_probability_field(m, 0.5, 0.5)
+        for seed in range(1, 6):
+            reuse = sample_occupancy(m, field, n, seed)
+            one_shot = sample_occupied_cells(m, 0.5, 0.5, seed=seed)
+            assert np.array_equal(reuse, one_shot)
+
+    def test_reused_field_still_varies_between_seeds(self):
+        # Reusing the field must not make realizations deterministic.
+        m = self._mask()
+        field, n = compute_crown_probability_field(m, 0.5, 0.5)
+        a = sample_occupancy(m, field, n, seed=1)
+        b = sample_occupancy(m, field, n, seed=2)
+        assert not np.array_equal(a, b)
+
+    def test_n_scales_with_rho(self):
+        m = self._mask()
+        _, n = compute_crown_probability_field(m, 0.5, 0.5, rho=0.5)
+        assert n == int(np.count_nonzero(m) * 0.5)
 
 
 class TestVoxelizedTree:


### PR DESCRIPTION
## Summary

Splits `sample_occupied_cells` into a deterministic + stochastic seam so a caller drawing multiple occupancy realizations of one crown can compute the (EDT-heavy) probability field **once** and draw many times, instead of recomputing it per realization. `sample_occupied_cells` stays as a byte-identical one-shot wrapper.

## API (new, exported from `fastfuels_core.voxelization`)

- `compute_crown_probability_field(vfa, alpha, beta, rho=None) -> (field, n)` — **deterministic**: the joint crown-occupancy probability grid and the number of voxels to draw. Depends only on the mask/params, not on any seed.
- `sample_occupancy(vfa, field, n, seed=None) -> occupancy` — **stochastic**: one occupancy realization drawn from a precomputed field.
- `sample_occupied_cells(...)` — unchanged behavior; now `sample_occupancy(vfa, *compute_crown_probability_field(...), seed)`.

## Why

`sample_occupied_cells` is the primary voxelization bottleneck in the treevox consumer (~190 µs/tree at 0.5 m). It runs per realization, and the deterministic field/EDT was recomputed on every call even though it depends only on `(mask, alpha, beta, rho)`. This exposes the seam so treevox (silvxlabs/FastFuels-API-v2#399) can hoist the field out of its per-realization loop — up to ~2× on `build_chunk_cache`. The design is intentional: within-bin variation comes from drawing different voxel subsets of **one shared field**, not from varying the field.

## Correctness

- New `TestOccupancySeam`: `sample_occupancy(vfa, *compute_crown_probability_field(...), seed)` is **byte-identical** to `sample_occupied_cells(...)` across `alpha`/`beta`/`rho`/`seed`; the field is deterministic; a reused field still varies across seeds.
- The existing `TestSampleCrownVoxels` contract is unchanged. Full suite green.
- End-to-end on a real ponderosa crown: 40 draws, hoisted vs one-shot identical per seed, 40/40 distinct realizations, 4.7× faster.

Closes #85.
