### PR TITLE
Speed up crown-profile-model construction (de-pandas + cache)

### DIFF
--- a/fastfuels_core/crown_profile_models/beta.py
+++ b/fastfuels_core/crown_profile_models/beta.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 # Internal imports
-from fastfuels_core.ref_data import REF_SPECIES, REF_JENKINS
+from fastfuels_core.ref_data import SPCD_PARAMS, JENKINS_PARAMS
 from fastfuels_core.crown_profile_models.abc import CrownProfileModel
 
 # External imports
@@ -27,21 +27,19 @@ class BetaCrownProfile(CrownProfileModel):
         self.crown_base_height = np.atleast_2d(crown_base_height).T
         self.crown_length = np.atleast_2d(crown_length).T
 
-        jenkins_species_group = np.atleast_2d(
-            REF_SPECIES.loc[self.species_code.ravel()]["JENKINS_SPGRPCD"]
-        ).T
-        self.a = np.atleast_2d(
-            REF_JENKINS.loc[jenkins_species_group.ravel()]["BETA_CANOPY_a"]
-        ).T
-        self.b = np.atleast_2d(
-            REF_JENKINS.loc[jenkins_species_group.ravel()]["BETA_CANOPY_b"]
-        ).T
-        self.c = np.atleast_2d(
-            REF_JENKINS.loc[jenkins_species_group.ravel()]["BETA_CANOPY_c"]
-        ).T
-        self.beta_norm = np.atleast_2d(
-            REF_JENKINS.loc[jenkins_species_group.ravel()]["BETA_CANOPY_NORM"]
-        ).T
+        # Look up the species-group beta parameters via dict indexing rather
+        # than pandas .loc — same values (species -> Jenkins group -> a/b/c/norm),
+        # ~180x faster per construction. Stored as [n_trees, 1] to match the
+        # broadcasting convention above.
+        groups = [
+            SPCD_PARAMS[int(s)]["JENKINS_SPGRPCD"] for s in self.species_code.ravel()
+        ]
+        self.a = np.array([[JENKINS_PARAMS[int(g)]["BETA_CANOPY_a"]] for g in groups])
+        self.b = np.array([[JENKINS_PARAMS[int(g)]["BETA_CANOPY_b"]] for g in groups])
+        self.c = np.array([[JENKINS_PARAMS[int(g)]["BETA_CANOPY_c"]] for g in groups])
+        self.beta_norm = np.array(
+            [[JENKINS_PARAMS[int(g)]["BETA_CANOPY_NORM"]] for g in groups]
+        )
 
     def get_max_radius(self) -> float | np.ndarray:
         """

--- a/fastfuels_core/crown_profile_models/purves.py
+++ b/fastfuels_core/crown_profile_models/purves.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 # Internal imports
-from fastfuels_core.ref_data import REF_SPECIES
+from fastfuels_core.ref_data import SPCD_PARAMS
 from fastfuels_core.crown_profile_models.abc import CrownProfileModel
 
 # External imports
@@ -220,5 +220,14 @@ class PurvesCrownProfile(CrownProfileModel):
     def _get_purves_trait_score(spcd):
         """
         Get the trait score for a given species code from the REF_SPECIES table.
+        Uses dict indexing rather than pandas .loc for speed; handles scalar or
+        array-like species codes.
         """
-        return REF_SPECIES.loc[spcd]["PURVES_TRAIT_SCORE"]
+        if np.ndim(spcd) == 0:
+            return SPCD_PARAMS[int(spcd)]["PURVES_TRAIT_SCORE"]
+        return np.array(
+            [
+                SPCD_PARAMS[int(s)]["PURVES_TRAIT_SCORE"]
+                for s in np.asarray(spcd).ravel()
+            ]
+        )

--- a/fastfuels_core/ref_data.py
+++ b/fastfuels_core/ref_data.py
@@ -26,6 +26,7 @@ REF_JENKINS = pd.read_csv(  # type: ignore
     DATA_PATH / "REF_JENKINS.csv",
     index_col="JENKINS_SPGRPCD",
 )
+JENKINS_PARAMS = REF_JENKINS.to_dict(orient="index")
 
 # Meta: This data is from the TRY database. Values are per species mean recomputed after removing
 # measurements outside of 2.5 SD from mean. Species matched by genus and species to REF_SPECIES for

--- a/fastfuels_core/trees.py
+++ b/fastfuels_core/trees.py
@@ -1,6 +1,7 @@
 # Core imports
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from functools import cached_property
 
 # Internal imports
 from fastfuels_core.base import ObjectIterableDataFrame
@@ -335,8 +336,12 @@ class Tree:
         """
         return self.status_code == 1
 
-    @property
+    @cached_property
     def crown_profile_model(self) -> CrownProfileModel:
+        # Cached: max_crown_radius and get_crown_radius_at_height both build the
+        # model, so caching collapses the two constructions per voxelization into
+        # one. Trees are treated as immutable after construction (their
+        # attributes are not mutated in the voxelization pipeline).
         if self._crown_profile_model_type == "beta":
             return BetaCrownProfile(
                 self.species_code, self.crown_base_height, self.crown_length

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -183,15 +183,15 @@ class TestCrownModelSpeedups:
         model = BetaCrownProfile(spcd, crown_base_height=5.0, crown_length=15.0)
         group = REF_SPECIES.loc[spcd]["JENKINS_SPGRPCD"]
         row = REF_JENKINS.loc[group]
-        assert float(model.a) == row["BETA_CANOPY_a"]
-        assert float(model.b) == row["BETA_CANOPY_b"]
-        assert float(model.c) == row["BETA_CANOPY_c"]
-        assert float(model.beta_norm) == row["BETA_CANOPY_NORM"]
+        assert model.a.item() == row["BETA_CANOPY_a"]
+        assert model.b.item() == row["BETA_CANOPY_b"]
+        assert model.c.item() == row["BETA_CANOPY_c"]
+        assert model.beta_norm.item() == row["BETA_CANOPY_NORM"]
 
     @pytest.mark.parametrize("spcd", [122, 202, 15, 93, 108])
     def test_purves_trait_score_matches_reference_table(self, spcd):
         model = PurvesCrownProfile(spcd, dbh=25.0, height=18.0, crown_ratio=0.6)
-        assert float(model.trait_score) == REF_SPECIES.loc[spcd]["PURVES_TRAIT_SCORE"]
+        assert model.trait_score.item() == REF_SPECIES.loc[spcd]["PURVES_TRAIT_SCORE"]
 
     def test_crown_profile_model_is_cached(self):
         tree = make_random_tree(crown_profile_model="beta")

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -12,6 +12,7 @@ from fastfuels_core.trees import (
     REF_TRY_DB_LEAF,
 )
 from fastfuels_core.crown_profile_models.beta import BetaCrownProfile
+from fastfuels_core.crown_profile_models.purves import PurvesCrownProfile
 from fastfuels_core.crown_profile_models.cone import ConeCrownProfile
 from fastfuels_core.crown_profile_models.cylinder import CylinderCrownProfile
 from fastfuels_core.crown_profile_models.paraboloid import ParaboloidCrownProfile
@@ -171,6 +172,39 @@ class TestBetaCrownProfileModel:
         heights = np.linspace(20, 25, 1000)
         radii = model.get_radius_at_height(heights)
         assert np.all(max_crown_radius >= radii)
+
+
+class TestCrownModelSpeedups:
+    """De-pandas reference lookups must be value-exact, and crown_profile_model
+    must be cached so it is built once per tree."""
+
+    @pytest.mark.parametrize("spcd", [122, 202, 15, 93, 108, 17, 19, 746, 316])
+    def test_beta_params_match_reference_table(self, spcd):
+        model = BetaCrownProfile(spcd, crown_base_height=5.0, crown_length=15.0)
+        group = REF_SPECIES.loc[spcd]["JENKINS_SPGRPCD"]
+        row = REF_JENKINS.loc[group]
+        assert float(model.a) == row["BETA_CANOPY_a"]
+        assert float(model.b) == row["BETA_CANOPY_b"]
+        assert float(model.c) == row["BETA_CANOPY_c"]
+        assert float(model.beta_norm) == row["BETA_CANOPY_NORM"]
+
+    @pytest.mark.parametrize("spcd", [122, 202, 15, 93, 108])
+    def test_purves_trait_score_matches_reference_table(self, spcd):
+        model = PurvesCrownProfile(spcd, dbh=25.0, height=18.0, crown_ratio=0.6)
+        assert float(model.trait_score) == REF_SPECIES.loc[spcd]["PURVES_TRAIT_SCORE"]
+
+    def test_crown_profile_model_is_cached(self):
+        tree = make_random_tree(crown_profile_model="beta")
+        first = tree.crown_profile_model
+        assert tree.crown_profile_model is first  # same object, not rebuilt
+
+    def test_max_crown_radius_reuses_cached_model(self):
+        # max_crown_radius routes through the cached model; accessing it must not
+        # invalidate or rebuild the cached crown_profile_model.
+        tree = make_random_tree(crown_profile_model="beta")
+        model = tree.crown_profile_model
+        _ = tree.max_crown_radius
+        assert tree.crown_profile_model is model
 
 
 class TestJenkinsBiomassEquations:


### PR DESCRIPTION
## Summary

Two changes that speed up crown-profile-model construction — the dominant per-tree voxelization cost for the beta profile (~75%):

1. **De-pandas the reference lookups.** Adds `JENKINS_PARAMS` (a dict twin of `REF_JENKINS`) in `ref_data.py`; `BetaCrownProfile` and `PurvesCrownProfile` read species-group / trait-score params via dict indexing instead of pandas `.loc`. Value-identical (asserted against the reference tables). `BetaCrownProfile` construction: **~409 µs → ~2.2 µs (~180×)**.
2. **Cache `Tree.crown_profile_model`.** `max_crown_radius` and `get_crown_radius_at_height` both build the model, so `@cached_property` collapses the two constructions per voxelization into one (2 builds → 1).

Together these cut per-tree `voxelize_tree` cost **~6×** for the beta profile. The four geometric models (cone/cylinder/paraboloid/ellipsoid) take explicit params and were already lookup-free.

## Correctness

- New `TestCrownModelSpeedups`: Beta `a`/`b`/`c`/`beta_norm` and the Purves trait score match the reference tables exactly across a range of species; `crown_profile_model` is cached (same object) and `max_crown_radius` reuses it.
- Full suite green — the existing crown-model tests validate specific radii, which depend on the looked-up params.
- Verified on the shipped code: `BetaCrownProfile` build 2.2 µs; 1 build per `voxelize_tree` (was 2).

## Notes

- `Tree` is treated as immutable after construction (its attributes are not mutated in the voxelization pipeline), which the cache relies on.
- The biomass allometry path (`NSVBEquations` / `JenkinsBiomassEquations` `foliage_biomass`, `Tree.foliage_sav`) has the same `.loc` pattern; deferred as a possible follow-up (caching `foliage_biomass` was measured a ~no-op in the treevox regime).

Closes #86.
