### PR TITLE
Ignore local CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ figures/
 
 # Auto-generated version file
 fastfuels_core/_version.py
+
+# Local Claude Code guidance (personal, not shared)
+CLAUDE.md


### PR DESCRIPTION
`CLAUDE.md` is personal Claude Code guidance kept locally (it was untracked). Add it to `.gitignore` so it no longer shows up as an untracked file in `git status`.