### PR TITLE
Refactor DensityField into a crown weight function

### DIFF
--- a/fastfuels_core/trees.py
+++ b/fastfuels_core/trees.py
@@ -414,12 +414,17 @@ class Tree:
                 self.height,
             )
 
-    @property
+    @cached_property
     def foliage_biomass(self) -> float:
         """
         Returns the foliage biomass of the tree. When a custom crown_fuel_load
         is set, returns that value directly. Otherwise computes from allometric
         equations.
+
+        Cached: constant for the tree's life (its inputs are fixed at
+        construction), and read once per occupancy realization by the mass
+        distribution. Trees are treated as immutable after construction, the
+        same assumption ``crown_profile_model`` relies on.
         """
         if self._crown_fuel_load_override is not None:
             return self._crown_fuel_load_override

--- a/fastfuels_core/voxelization/mass_distribution.py
+++ b/fastfuels_core/voxelization/mass_distribution.py
@@ -5,13 +5,21 @@ subgrid sampling) produces a volume-fraction grid; a ``DensityField`` then turns
 that occupancy into a bulk-density grid (kg/m^3) by deciding *how much* of the
 crown mass sits in each voxel.
 
+A ``DensityField`` is a **crown weight function**: it supplies the relative
+weight of each occupied voxel via :meth:`DensityField.crown_weight`. The
+mass-conserving normalization -- scale the weighted occupancy so its integral
+equals the tree's crown mass -- is shared and lives in
+:meth:`VoxelizedTree.distribute_biomass`, so subclasses only choose the *shape*
+of the distribution.
+
 Two flavors ship here:
 
-* :class:`UniformDensity` -- one constant bulk density through the crown
-  (mass / occupied volume). This is the original behavior.
-* :class:`GradientDensity` -- distribute mass with an arbitrary weight function
-  ``w(r, z, tree)``; the result is renormalized to conserve the crown mass, so a
-  constant weight recovers :class:`UniformDensity`. Named subclasses (e.g.
+* :class:`UniformDensity` -- a constant weight, giving one bulk density through
+  the crown (mass / occupied volume). This is the original behavior, and it
+  reads no crown geometry.
+* :class:`GradientDensity` -- an arbitrary weight function ``w(r, z, tree)``.
+  Because of the shared renormalization a constant weight recovers
+  :class:`UniformDensity`. Named subclasses (e.g.
   :class:`LinearHeightQuadraticRadialDensity`) pin a specific weight.
 
 The occupancy step and the mass-distribution step are deliberately independent:
@@ -28,6 +36,7 @@ from numpy import ndarray
 
 if TYPE_CHECKING:
     from fastfuels_core.trees import Tree
+    from fastfuels_core.voxelization.tree import VoxelizedTree
 
 # A weight function maps per-voxel radial distance ``r`` and height ``z`` (plus
 # the tree, for geometry) to non-negative relative weights over the voxel grid.
@@ -35,23 +44,32 @@ WeightFunction = Callable[[ndarray, ndarray, "Tree"], ndarray]
 
 
 class DensityField(ABC):
-    """Turns an occupancy grid into a bulk-density grid (kg/m^3).
+    """A crown weight function for distributing crown mass over occupied voxels.
 
-    Implementations receive the ``occupancy`` grid (volume fraction per voxel),
-    the ``tree``, per-voxel radial distance ``r`` and height ``z`` (broadcastable
-    to the grid), and the ``cell_volume`` (m^3), and return a bulk-density grid
-    of the same shape as ``occupancy``.
+    Implementations return the relative weight of each occupied voxel; the
+    shared, mass-conserving normalization in
+    :meth:`VoxelizedTree.distribute_biomass` turns those weights into a
+    bulk-density grid (kg/m^3). A constant weight yields uniform density.
     """
 
     @abstractmethod
-    def apply(
-        self,
-        occupancy: ndarray,
-        tree: "Tree",
-        r: ndarray,
-        z: ndarray,
-        cell_volume: float,
-    ) -> ndarray:
+    def crown_weight(self, vt: "VoxelizedTree") -> ndarray | float:
+        """Return the relative weight of each occupied voxel.
+
+        Parameters
+        ----------
+        vt : VoxelizedTree
+            The voxelized tree being distributed. Weights that vary with crown
+            geometry read ``vt.voxel_height`` and ``vt.radial_distance``, which
+            are computed lazily -- a constant weight never triggers them.
+
+        Returns
+        -------
+        ndarray or float
+            Per-voxel relative weights broadcastable to ``vt.grid``, or a scalar
+            for a spatially constant weight. Need not be normalized;
+            ``distribute_biomass`` renormalizes to conserve the crown mass.
+        """
         raise NotImplementedError
 
 
@@ -59,14 +77,12 @@ class UniformDensity(DensityField):
     """Constant bulk density through the crown: ``mass / occupied volume``.
 
     Equivalent to the original ``VoxelizedTree.distribute_biomass``: the whole
-    crown mass is spread at a single bulk density over the occupied volume.
+    crown mass is spread at a single bulk density over the occupied volume. The
+    weight is a spatially constant ``1.0``, so it reads no crown geometry.
     """
 
-    def apply(self, occupancy, tree, r, z, cell_volume):
-        volume = float(occupancy.sum()) * cell_volume
-        if volume <= 0.0:
-            return np.zeros_like(occupancy, dtype=float)
-        return occupancy * (tree.foliage_biomass / volume)
+    def crown_weight(self, vt):
+        return 1.0
 
 
 class GradientDensity(DensityField):
@@ -81,20 +97,18 @@ class GradientDensity(DensityField):
     weight_fn : callable
         ``weight_fn(r, z, tree) -> ndarray`` returning non-negative relative
         weights broadcast over the voxel grid. ``r`` is the radial distance from
-        the stem and ``z`` the height; both are broadcastable to the occupancy
-        grid. Any new gradient is just a new weight function.
+        the stem (``vt.radial_distance``) and ``z`` the height
+        (``vt.voxel_height``); both are broadcastable to the occupancy grid. Any
+        new gradient is just a new weight function.
     """
 
     def __init__(self, weight_fn: WeightFunction):
         self.weight_fn = weight_fn
 
-    def apply(self, occupancy, tree, r, z, cell_volume):
-        weight = np.asarray(self.weight_fn(r, z, tree), dtype=float)
-        raw = weight * occupancy
-        total = float(raw.sum()) * cell_volume
-        if total <= 0.0:
-            return np.zeros_like(occupancy, dtype=float)
-        return raw * (tree.foliage_biomass / total)
+    def crown_weight(self, vt):
+        return np.asarray(
+            self.weight_fn(vt.radial_distance, vt.voxel_height, vt.tree), dtype=float
+        )
 
 
 def _linear_height_quadratic_radial(r: ndarray, z: ndarray, tree: "Tree") -> ndarray:

--- a/fastfuels_core/voxelization/tree.py
+++ b/fastfuels_core/voxelization/tree.py
@@ -1,5 +1,6 @@
 # Core imports
 from __future__ import annotations
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 # Internal imports
@@ -42,28 +43,46 @@ class VoxelizedTree:
     def distribute_biomass(self, density_field: DensityField = None) -> ndarray:
         """Distribute the tree's crown mass across occupied voxels.
 
-        The mass-distribution step is independent of how the occupancy grid was
-        produced. ``density_field`` selects the distribution; it defaults to
-        :class:`UniformDensity`, reproducing the original constant-density
-        behavior.
+        A ``density_field`` supplies the relative weight of each occupied voxel
+        (see :class:`DensityField`); this method applies the shared,
+        mass-conserving normalization so the integrated bulk density equals the
+        tree's crown mass. Defaults to :class:`UniformDensity` (a constant
+        weight), reproducing the original constant-density behavior.
         """
         if density_field is None:
             density_field = UniformDensity()
-        z, r = self._voxel_coordinates()
+        weight = density_field.crown_weight(self)
+        raw = weight * self.grid
         cell_volume = self.hr * self.hr * self.vr
-        return density_field.apply(self.grid, self.tree, r, z, cell_volume)
+        total = float(raw.sum()) * cell_volume
+        if total <= 0.0:
+            return np.zeros_like(self.grid, dtype=float)
+        return raw * (self.tree.foliage_biomass / total)
 
-    def _voxel_coordinates(self) -> tuple[ndarray, ndarray]:
-        """Per-voxel height ``z`` (nz,1,1) and radial distance from the stem
-        ``r`` (1,ny,nx), matching ``self.grid``'s axes."""
+    @cached_property
+    def voxel_height(self) -> ndarray:
+        """Per-voxel height above the grid's z-reference, shape ``(nz, 1, 1)``.
+
+        Broadcasts over the horizontal axes. Computed lazily on first access --
+        a constant-weight density field (e.g. :class:`UniformDensity`) never
+        triggers it -- and cached thereafter.
+        """
         z = _get_vertical_tree_coords(
             self.vr, self.tree.height, self.tree.crown_base_height, self.z_origin
         )
+        return z[:, None, None]
+
+    @cached_property
+    def radial_distance(self) -> ndarray:
+        """Per-voxel horizontal distance from the stem axis, shape ``(1, ny, nx)``.
+
+        Broadcasts over the vertical axis. Computed lazily on first access and
+        cached thereafter.
+        """
         xy = _get_horizontal_tree_coords(
             self.hr, self.tree.max_crown_radius, centering=self.centering
         )
-        r = np.sqrt(xy[None, :] ** 2 + xy[:, None] ** 2)
-        return z[:, None, None], r[None, :, :]
+        return np.sqrt(xy[None, :] ** 2 + xy[:, None] ** 2)[None, :, :]
 
 
 def voxelize_tree(

--- a/tests/test_mass_distribution.py
+++ b/tests/test_mass_distribution.py
@@ -138,7 +138,7 @@ class TestLinearHeightQuadraticRadialDensity:
 
     def test_is_top_weighted_relative_to_uniform(self):
         vt = _full_occupancy(_paraboloid_tree())
-        z = vt._voxel_coordinates()[0].ravel()
+        z = vt.voxel_height.ravel()
         uniform = vt.distribute_biomass(UniformDensity())
         lanl = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
 
@@ -149,7 +149,7 @@ class TestLinearHeightQuadraticRadialDensity:
 
     def test_is_outer_weighted_relative_to_uniform(self):
         vt = _full_occupancy(_paraboloid_tree())
-        _, r = vt._voxel_coordinates()
+        r = vt.radial_distance
         r = np.broadcast_to(r, vt.grid.shape)
         uniform = vt.distribute_biomass(UniformDensity())
         lanl = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())

--- a/tests/test_z_origin.py
+++ b/tests/test_z_origin.py
@@ -85,7 +85,7 @@ class TestVoxelizeTreeThreadsZOrigin:
         tree = _paraboloid_tree()
         vt = voxelize_tree(tree, 2.0, 1.0, alpha=0.0, beta=0.0, rho=1.0, z_origin=0.0)
         assert vt.z_origin == 0.0
-        z, _ = vt._voxel_coordinates()
+        z = vt.voxel_height
         # density-field heights align to the same half-integer grid
         assert np.allclose(z.ravel() % 1.0, 0.5)
 
@@ -107,7 +107,7 @@ class TestVoxelizeTreeThreadsZOrigin:
         # density and must stay non-negative; mass is still conserved.
         tree = _paraboloid_tree(cbh=3.9)
         vt = voxelize_tree(tree, 2.0, 1.0, alpha=0.0, beta=0.0, rho=1.0, z_origin=0.0)
-        z, _ = vt._voxel_coordinates()
+        z = vt.voxel_height
         assert z.ravel()[0] < tree.crown_base_height  # precondition for the bug
         bulk = vt.distribute_biomass(LinearHeightQuadraticRadialDensity())
         assert np.all(bulk >= 0.0)


### PR DESCRIPTION
## Summary

`distribute_biomass` eagerly computed per-voxel crown geometry (`z`, `r`) and
passed it to `DensityField.apply`, but `UniformDensity` — the default, and
treevox's path — ignores it, so the geometry was built and discarded on every
occupancy realization.

This recasts `DensityField` as a **crown weight function**:

- `DensityField.crown_weight(vt)` replaces `apply(...)`. `UniformDensity`
  returns the scalar `1.0` (reads no geometry); `GradientDensity` reads
  `vt.radial_distance` / `vt.voxel_height`.
- `distribute_biomass` applies the single, shared mass-conserving normalization
  — the two near-identical `apply` bodies collapse into one.
- Coordinates become named, lazy `@cached_property` on `VoxelizedTree`
  (`voxel_height`, `radial_distance`), retiring `_voxel_coordinates()` and its
  order-flipping `(z, r)` tuple. A constant-weight field never triggers them.
- `Tree.foliage_biomass` → `@cached_property`.

## Verification

- Full suite: **25,508 passed**.
- **Byte-identical** on both paths — uniform `max|Δ| = 0.0` vs the legacy
  `occupancy * foliage_biomass / volume` (asserted by
  `test_matches_legacy_formula_exactly` via `np.array_equal`); gradient
  mass-conservation tests unchanged.
- Uniform path never materializes `voxel_height` / `radial_distance` (verified
  via `vt.__dict__`).
- Uniform `distribute_biomass`: **~13–15 µs → ~1.5 µs**.

## API

`distribute_biomass(density_field=None) -> ndarray` is unchanged, so downstream
(treevox) needs no code change — it gets the speedup on the next bump.
`DensityField.apply` → `crown_weight` is a signature change to the days-old
composable `mass_distribution` API (#82/#83) with no external subclasses.

Closes #91
